### PR TITLE
Change all to -moz-all for -moz-user-select

### DIFF
--- a/muckrock/foiamachine/assets/scss/style.scss
+++ b/muckrock/foiamachine/assets/scss/style.scss
@@ -107,7 +107,7 @@ td p {
 }
 .select-all {
     -webkit-user-select: all;
-    -moz-user-select: all;
+    -moz-user-select: -moz-all;
     user-select: all;
 }
 .nostyle {


### PR DESCRIPTION
Fixes #1242. It looks like Firefox requires a vendor prefix for the value of `-moz-user-select`. The behavior isn't exactly the same as the other browsers, but it's now selectable. Tested locally with the Firefox 56 and the nightly build of 57. Let me know if there's anything I missed!