### PR TITLE
Per-page RSS feeds

### DIFF
--- a/muckrock/templates/accounts/profile.html
+++ b/muckrock/templates/accounts/profile.html
@@ -8,6 +8,11 @@
 {% endblock title %}
 {% block type %}account{% endblock type %}
 
+{% block rss %}
+{{ block.super }}
+<link rel="alternate" type="application/rss+xml" title="{{user_obj.get_full_name}}'s FOIA Feed" href="{% url 'foia-user-feed' user_obj.username %}" />
+{% endblock rss %}
+
 {% block open_graph %}
   <meta property="og:type" content="profile" />
   <meta property="og:url" content="{{user_obj.get_absolute_url}}" />

--- a/muckrock/templates/base.html
+++ b/muckrock/templates/base.html
@@ -13,6 +13,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="google-site-verification" content="j3QyPvF_0QX1v2YTWeY0Al5JCiBVdxhDjJM5JgFkxVE" />
     <meta name="google-site-verification" content="4KnIEDr5Fi-PUL9klVnMlC2BMcStrUwQIj-4gMVfqjk" />
+    {% block rss %}
+    <link rel="alternate" type="application/rss+xml" title="MuckRock News Feed" href="{% url 'news-feed' %}" />
+    {% endblock rss %}
     <!-- Load Assets -->
     <link rel="shortcut icon"       href="{% static 'icons/favicon.ico' %}" />
     <link rel="mask-icon"           href="{% static 'icons/favicon.svg' %}" color="#367AF0" />

--- a/muckrock/templates/foia/detail.html
+++ b/muckrock/templates/foia/detail.html
@@ -11,6 +11,11 @@
 {% block title %}{{ foia.title }} &bull; MuckRock{% endblock %}
 {% block type %}request{% endblock %}
 
+{% block rss %}
+{{ block.super }}
+<link rel="alternate" type="application/rss+xml" title="{{foia.title}} Feed" href="{% url 'foia-feed' foia.id %}" />
+{% endblock rss %}
+
 {% block open_graph %}
   {% cache cache_timeout foia_detail_open_graph foia.pk request.user.pk %}
     <meta property="og:title" content="{{ foia.title }}" />


### PR DESCRIPTION
I saw @morisy's ask for RSS meta tags in the latest dev email update, and it was a pretty straightforward thing to start implementing.

This should provide a basic pattern for linking RSS feeds to the root pages they're related to. It's not comprehensive (or tested!), so this PR shouldn't be merged yet, and the branch could be developed further. But I hope it helps!