### PR TITLE
Remove clone link, embargo status, tags from non logged in users

### DIFF
--- a/muckrock/templates/foia/detail.html
+++ b/muckrock/templates/foia/detail.html
@@ -62,7 +62,7 @@
       {% social title=foia.title url=foia.get_absolute_url %}
       <section class="basic-information">
         <summary class="synopsis"><a href="{% url 'acct-profile' foia.user.username %}">{{ foia.user.get_full_name }}</a> filed this request{% if foia.agency %} with the {{foia.agency.link_display}} of {% if foia.jurisdiction.level == 'f' %}the {% endif %}<a href="{{ foia.jurisdiction.get_absolute_url }}">{{ foia.jurisdiction.name }}</a>{% if foia.jurisdiction.parent and foia.jurisdiction.level == 'l' %}, <a href="{{ foia.jurisdiction.parent.get_absolute_url }}" title="{{ foia.jurisdiction.parent.name }}">{{ foia.jurisdiction.parent.abbrev }}</a>{% endif %}{% endif %}.</summary>
-        {% if foia.composer.parent %}
+        {% if foia.composer.parent and user_can_edit %}
           <p>It is a clone of <a href="{{ foia.composer.parent.get_absolute_url }}">this request</a>.</p>
         {% endif %}
       </section>

--- a/muckrock/templates/foia/detail.html
+++ b/muckrock/templates/foia/detail.html
@@ -160,11 +160,11 @@
               <button class="cancel button">Cancel</button>
             </footer>
           </form>
-        {% endif %}
-        {% include 'foia/component/status.html' %}
         {% include 'foia/component/embargo.html' %}
         {% project_manager foia %}
         {% tag_manager foia %}
+        {% endif %}
+        {% include 'foia/component/status.html' %}
       </section>
     </section>
   {% endcache %}


### PR DESCRIPTION
When someone receives a FOIA request and uses the link in the email to fulfill the documents, the fact that the request is cloned, if it is embargoed, or any tags that have been assigned on it should not be shared (similar to notes and tasks).