### PR TITLE
Include Subject of earlier communications

### DIFF
--- a/muckrock/templates/text/foia/comms.txt
+++ b/muckrock/templates/text/foia/comms.txt
@@ -1,4 +1,5 @@
 {% autoescape off %}{% for comm in msg_comms %}{% if not forloop.first %}On {{ comm.datetime|date }}:
+Subject: {{comm.subject}}
 {% endif %}{{ comm.communication }}
 {% if forloop.first or forloop.last %}
 {% include "text/foia/msg_footer.txt" %}{% endif %}{% if not forloop.last %}---


### PR DESCRIPTION
In certain cases, for example: https://www.muckrock.com/foi/united-states-of-america-10/wank-worm-investigation-71353/ , the agency includes the reference number or other important information in their reply subject, and nowhere in the body.  This change would allow agencies to more easily cross-reference a follow-up communication sent by MuckRock with their FOIA database.

TESTED=false