### PR TITLE
Handle multiple reference numbers

### DIFF
--- a/muckrock/foia/models/request.py
+++ b/muckrock/foia/models/request.py
@@ -1190,7 +1190,7 @@ class FOIARequest(models.Model):
     def default_subject(self):
         """Make a subject line for a communication for this request"""
         law_name = self.jurisdiction.get_law_name()
-        tracking_id = self.current_tracking_id()
+        tracking_id = self.all_tracking_ids()
         if tracking_id:
             return 'RE: %s Request #%s' % (law_name, tracking_id)
         elif self.communications.count() > 1:
@@ -1211,7 +1211,7 @@ class FOIARequest(models.Model):
         # it on to the end
         if comms[-1] != comm:
             comms.append(comm)
-        # if theirs only one communication, do not double include it
+        # if there's only one communication, do not double include it
         if len(comms) == 1:
             return comms
         # always show the latest message
@@ -1287,6 +1287,14 @@ class FOIARequest(models.Model):
         else:
             self._tracking_id = ''
         return self._tracking_id
+    
+    def all_tracking_ids(self):
+        """Gets all the tracking ids as a single string"""
+        tracking_ids = self.tracking_ids.all()
+        if tracking_ids:
+            return ', '.join(set(e.tracking_id for e in self.tracking_ids.all()))
+        else:
+            return ''
 
     def add_tracking_id(self, tracking_id, reason=None):
         """Add a new tracking ID"""

--- a/muckrock/templates/text/foia/request_msg.txt
+++ b/muckrock/templates/text/foia/request_msg.txt
@@ -3,8 +3,8 @@
 {% endif %}
 
 {% now "F j, Y" %}
-{% if request.communications.count > 1 %}{% if request.current_tracking_id %}
-This is a follow up to request number {{request.current_tracking_id}}:{% else %}
+{% if request.communications.count > 1 %}{% if request.all_tracking_ids %}
+This is a follow up to request number {{request.all_tracking_ids}}:{% else %}
 This is a follow up to a previous request:{% endif %}{% endif %}
 {% if switch %}This request was originally submitted via {{ original.method }}{% if original.addr %} to {{ original.addr }}{% endif %}.  {% if last_resp %}It was last responded to on {{ last_resp.date|date }} via {{ last_resp.method }}{% if last_resp.addr %} by {{ last_resp.addr }}{% endif %}.{% else %}It was never acknowledged.{% endif %}  Due to issues with the original communication method, we are now directing this request to you. {% endif %}
 {% include "text/foia/comms.txt" %}


### PR DESCRIPTION
Sometimes requests have multiple reference numbers because agencies refer them to multiple agencies or split them into multiple subrequests.

This "seems" right but I am not able to run the system or tests - sorry!

Contribution is licensed back under: https://github.com/muckrock/muckrock/blob/270cbaacdf705182cc0f2dc8c8149b30c35de9be/license.md