### PR TITLE
fix: handle files without MIME types

### DIFF
--- a/muckrock/assets/vendor/fine-uploader/index.js
+++ b/muckrock/assets/vendor/fine-uploader/index.js
@@ -3854,7 +3854,12 @@
                 return localStorageId;
             },
             _getMimeType: function(id) {
-                return handler.getFile(id).type;
+                // Custom handling to fall back on unknown mime types
+                var mimeType = handler.getFile(id).type;
+                if(!mimeType || mimeType == ""){
+                    mimeType = spec.options.defaultMimeType;
+                }
+                return mimeType;
             },
             _getPersistableData: function(id) {
                 return handler._getFileState(id).chunking;

--- a/muckrock/settings/base.py
+++ b/muckrock/settings/base.py
@@ -566,6 +566,7 @@ MAX_ATTACHMENT_SIZE = 5 * 1024 * 1024
 MAX_ATTACHMENT_NUM = 3
 # maximum for outgoing messages, including staff
 MAX_ATTACHMENT_TOTAL_SIZE = 20 * 1024 * 1024
+DEFAULT_UPLOAD_MIME_UNKNOWN = "application/octet-stream"
 ALLOWED_FILE_MIMES = [
     "application/pdf",
     "image/jpeg",

--- a/muckrock/templates/lib/component/fine-uploader.html
+++ b/muckrock/templates/lib/component/fine-uploader.html
@@ -113,7 +113,8 @@ function createCreateUploader(dataAttr, urls, spreadsheetsOnly) {
       request: {
         inputName: 'file',
         filenameParam: 'filename',
-        endpoint: ' ' // Replaced in onUpload handler
+        endpoint: ' ', // Replaced in onUpload handler
+        defaultMimeType: "{{settings.DEFAULT_UPLOAD_MIME_UNKNOWN}}"
       },
       credentials: {
         accessKey: " ",
@@ -147,6 +148,11 @@ function createCreateUploader(dataAttr, urls, spreadsheetsOnly) {
           var isChunked = uploader._handler.isUploadChunked(id);
           var promise = new qq.Promise();
 
+          var mimeType = uploader.getFile(id).type;
+          if(!mimeType || mimeType == ""){
+            mimeType = "{{settings.DEFAULT_UPLOAD_MIME_UNKNOWN}}";
+          }
+
           // Check if this upload has already begun (i.e. its being retried)
           if(uploader._s3FileKeys[id]){
             // We don't want to prefetch again, or it will overwrite the uploadId
@@ -160,7 +166,7 @@ function createCreateUploader(dataAttr, urls, spreadsheetsOnly) {
             data: { 
               name: filename, 
               id: pk,
-              type: uploader.getFile(id).type,
+              type: mimeType,
               chunked: isChunked
             },
             headers: { 'X-CSRFToken': '{{ csrf_token }}' }


### PR DESCRIPTION
The issue flagged this morning has two dimensions: first, that we don't want to validate MIME types for staff users, and second, that certain uploads were failing for certain unknown file types.

Your fix this morning solved the first, and this PR addresses the second — by falling back to the default `application/octet-stream` MIME type when the file is otherwise unknown. This way, every upload request is guaranteed to include a Content-Type — and we don't have to worry about conditional handling on `conditions` array depending on which values are available or not.

Unfortunately [the browser File.prototype.type](https://developer.mozilla.org/en-US/docs/Web/API/File/type) field returns an empty string when it encounters a file it's unfamiliar with, so I had to modify the Fine-Uploader library to support a default value. As in previous edits to this vendored file, I left a note — but since the library is fully deprecated, we won't be able to contribute this fix upstream to the library itself.