### PR TITLE
Add generic twitter:image to request detail page

### DIFF
--- a/muckrock/templates/foia/detail/twitter_card.html
+++ b/muckrock/templates/foia/detail/twitter_card.html
@@ -16,4 +16,5 @@
       {{ foia.jurisdiction.name }}.
     {% endif %}"
     />
+   <meta name="twitter:image:src" content="{% static 'icons/logo.png' %}" />
 {% endcache %}


### PR DESCRIPTION
To my eyes, it's better than nothing, which is causing this on Mastodon

![Screenshot from 2022-12-21 05-26-47](https://user-images.githubusercontent.com/9993/208916074-07f5544f-835c-4702-8672-26d010e3cac7.png) 