### PR TITLE
Small fixes for agency requests tab

### DIFF
--- a/muckrock/templates/agency/detail/tabs/requests.html
+++ b/muckrock/templates/agency/detail/tabs/requests.html
@@ -1,8 +1,5 @@
 <section role="tabpanel" class="tab-panel requests" id="requests">
-  <h2 class="tab-panel-heading">
-    Requests
-    {% if foia_requests_count > 10 %}<small><a href="{% url 'foia-list' %}?agency={{ agency.pk }}">See All</a></small>{% endif %}
-  </h2>
+  <h2 class="tab-panel-heading">Requests</h2>
   <div class="grid__row">
     <div class="grid__column quarter">
       <div class="grid___row">
@@ -16,7 +13,10 @@
     </div>
     <div class="grid__column three-quarters">
       {% if foia_requests_count > 0 %}
-      <h3>Recent Requests </h3>
+      <h3 class="foia-table-header">
+        Recent Requests
+        {% if foia_requests_count > 10 %}<small><a href="{% url 'foia-list' %}?agency={{ agency.pk }}">See All</a></small>{% endif %}
+      </h3>
       {% include 'lib/foia_table.html' with requests=foia_requests %}
       {% else %}
       <p>No requests made to this agency.</p>

--- a/muckrock/templates/lib/request_stats.html
+++ b/muckrock/templates/lib/request_stats.html
@@ -3,13 +3,13 @@
     {% if num_submitted %}
     <table>
     <tr><td>Filed</td><td><span class="blue counter">{{ num_submitted }}</span></td></tr>
-    {% if num_done %}<tr><td><span class="green counter">{{ num_done }}</span></td><td>Completed</td></tr>{% endif %}
-    {% if num_rejected %}<tr><td><span class="red counter">{{ num_rejected }}</span></td><td>Rejected</td></tr>{% endif %}
-    {% if num_no_docs %}<tr><td><span class="red counter">{{ num_no_docs }}</span></td><td>No Responsive Documents</td></tr>{% endif %}
-    {% if num_ack %}<tr><td><span class="counter">{{ num_ack }}</span></td><td>Awaiting Acknowledgement</td></tr>{% endif %}
-    {% if num_processed %}<tr><td><span class="counter">{{ num_processed }}</span></td><td>Awaiting Response</td></tr>{% endif %}
-    {% if num_fix %}<tr><td><span class="counter">{{ num_fix }}</span></td><td>Requiring Action</td></tr>{% endif %}
-    {% if num_overdue %}<tr><td><span class="red counter">{{ num_overdue }}</span></td><td>Overdue</td></tr>{% endif %}
+    {% if num_done %}<tr><td>Completed</td><td><span class="green counter">{{ num_done }}</span></td></tr>{% endif %}
+    {% if num_rejected %}<tr><td>Rejected</td><td><span class="red counter">{{ num_rejected }}</span></td></tr>{% endif %}
+    {% if num_no_docs %}<tr><td>No Responsive Documents</td><td><span class="red counter">{{ num_no_docs }}</span></td></tr>{% endif %}
+    {% if num_ack %}<tr><td>Awaiting Acknowledgement</td><td><span class="counter">{{ num_ack }}</span></td></tr>{% endif %}
+    {% if num_processed %}<tr><td>Awaiting Response</td><td><span class="counter">{{ num_processed }}</span></td></tr>{% endif %}
+    {% if num_fix %}<tr><td>Requiring Action</td><td><span class="counter">{{ num_fix }}</span></td></tr>{% endif %}
+    {% if num_overdue %}<tr><td>Overdue</td><td><span class="red counter">{{ num_overdue }}</span></td></tr>{% endif %}
     </table>
     {% else %}
     <p>None</p>


### PR DESCRIPTION
1. Fixes position of statuses in `request_stats` component
2. Reinstates "See All" link when more than 10 agency requests
<img width="1552" alt="Screenshot 2023-04-20 at 2 30 14 PM" src="https://user-images.githubusercontent.com/6089482/233456611-40d14fae-cbef-4355-9576-f8b168ac5885.png">
