### PR TITLE
Redirects help flatpages

### DIFF
--- a/compose/local/django/Dockerfile
+++ b/compose/local/django/Dockerfile
@@ -30,6 +30,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # set up makecert root CA
 RUN curl http://localhost/rootCA.pem > /usr/local/share/ca-certificates/rootCA.crt && update-ca-certificates
 
+
+RUN apt-get update && apt-get install -y libsodium-dev
+ENV SODIUM_INSTALL=system
+
 # install NVM
 ENV NVM_DIR /usr/local/nvm
 ENV NODE_VERSION 18.16.0
@@ -51,6 +55,11 @@ RUN curl https://cli-assets.heroku.com/install.sh | sh
 COPY ./pip /pip
 #RUN --mount=type=cache,target=/root/.cache/pip pip install -r /pip/requirements.txt
 #RUN --mount=type=cache,target=/root/.cache/pip pip install -r /pip/dev-requirements.txt
+# Update setuptools
+RUN pip install --upgrade setuptools>=61.0.0
+# Use pre-built wheel
+RUN pip install wheel
+# Install requirements
 RUN pip install -r /pip/requirements.txt
 RUN pip install -r /pip/dev-requirements.txt
 

--- a/compose/local/django/Dockerfile
+++ b/compose/local/django/Dockerfile
@@ -30,9 +30,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # set up makecert root CA
 RUN curl http://localhost/rootCA.pem > /usr/local/share/ca-certificates/rootCA.crt && update-ca-certificates
 
-# heroku cli
-RUN curl https://cli-assets.heroku.com/install.sh | sh
-
 # install NVM
 ENV NVM_DIR /usr/local/nvm
 ENV NODE_VERSION 18.16.0
@@ -46,6 +43,9 @@ RUN curl https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.3/install.sh | bash 
 
 ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
 ENV PATH      $NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH
+
+# heroku cli
+RUN curl https://cli-assets.heroku.com/install.sh | sh
 
 # Requirements are installed here to ensure they will be cached.
 COPY ./pip /pip

--- a/muckrock/core/middleware.py
+++ b/muckrock/core/middleware.py
@@ -1,0 +1,13 @@
+# middleware.py
+from django.http import HttpResponsePermanentRedirect
+from django.utils.deprecation import MiddlewareMixin
+from django.conf import settings
+
+class FlatpageRedirectMiddleware(MiddlewareMixin):
+    def process_response(self, request, response):
+        if response.status_code == 404:
+            path = request.path_info.lstrip('/')
+            redirects = getattr(settings, 'FLATPAGES_REDIRECTS', {})
+            if path in redirects:
+                return HttpResponsePermanentRedirect(redirects[path])
+        return response

--- a/muckrock/core/middleware.py
+++ b/muckrock/core/middleware.py
@@ -1,7 +1,8 @@
 # middleware.py
+# Django
+from django.conf import settings
 from django.http import HttpResponsePermanentRedirect
 from django.utils.deprecation import MiddlewareMixin
-from django.conf import settings
 
 
 class FlatpageRedirectMiddleware(MiddlewareMixin):

--- a/muckrock/core/middleware.py
+++ b/muckrock/core/middleware.py
@@ -3,12 +3,13 @@ from django.http import HttpResponsePermanentRedirect
 from django.utils.deprecation import MiddlewareMixin
 from django.conf import settings
 
+
 class FlatpageRedirectMiddleware(MiddlewareMixin):
     def process_response(self, request, response):
         if response.status_code == 404:
             site = request.get_host()
-            path = request.path_info.lstrip('/')
-            redirects = getattr(settings, 'FLATPAGES_REDIRECTS', {})
+            path = request.path_info.lstrip("/")
+            redirects = getattr(settings, "FLATPAGES_REDIRECTS", {})
             if site in redirects:
                 site_redirects = redirects[site]
                 if path in site_redirects:

--- a/muckrock/core/middleware.py
+++ b/muckrock/core/middleware.py
@@ -6,8 +6,11 @@ from django.conf import settings
 class FlatpageRedirectMiddleware(MiddlewareMixin):
     def process_response(self, request, response):
         if response.status_code == 404:
+            site = request.get_host()
             path = request.path_info.lstrip('/')
             redirects = getattr(settings, 'FLATPAGES_REDIRECTS', {})
-            if path in redirects:
-                return HttpResponsePermanentRedirect(redirects[path])
+            if site in redirects:
+                site_redirects = redirects[site]
+                if path in site_redirects:
+                    return HttpResponsePermanentRedirect(site_redirects[path])
         return response

--- a/muckrock/core/tests/test_middleware.py
+++ b/muckrock/core/tests/test_middleware.py
@@ -3,15 +3,17 @@ from django.http import HttpResponse, HttpResponseNotFound
 from muckrock.core.middleware import FlatpageRedirectMiddleware
 
 
-@override_settings(
-    ALLOWED_HOSTS=["www.muckrock.com", "www.foiamachine.org", "www.unknownsite.org"]
-)
 class FlatpageRedirectMiddlewareTests(TestCase):
     def setUp(self):
         self.factory = RequestFactory()
         self.middleware = FlatpageRedirectMiddleware(lambda request: HttpResponse())
 
     @override_settings(
+        ALLOWED_HOSTS=[
+            "www.muckrock.com",
+            "www.foiamachine.org",
+            "www.unknownsite.org",
+        ],
         FLATPAGES_REDIRECTS={
             "www.muckrock.com": {
                 "about/how-we-work/": "https://help.muckrock.com/how-we-work-redirect",
@@ -19,7 +21,7 @@ class FlatpageRedirectMiddlewareTests(TestCase):
             "www.foiamachine.org": {
                 "about/": "https://help.muckrock.com/foia-about-redirect",
             },
-        }
+        },
     )
     def test_redirect_muckrock_domain(self):
         # Request for a known route in the mocks above
@@ -33,6 +35,11 @@ class FlatpageRedirectMiddlewareTests(TestCase):
         )
 
     @override_settings(
+        ALLOWED_HOSTS=[
+            "www.muckrock.com",
+            "www.foiamachine.org",
+            "www.unknownsite.org",
+        ],
         FLATPAGES_REDIRECTS={
             "www.muckrock.com": {
                 "about/how-we-work/": "https://help.muckrock.com/how-we-work-redirect",
@@ -40,7 +47,7 @@ class FlatpageRedirectMiddlewareTests(TestCase):
             "www.foiamachine.org": {
                 "about/": "https://help.muckrock.com/foia-about-redirect",
             },
-        }
+        },
     )
     def test_redirect_foiamachine_domain(self):
         request = self.factory.get("/about/")
@@ -53,11 +60,16 @@ class FlatpageRedirectMiddlewareTests(TestCase):
         )
 
     @override_settings(
+        ALLOWED_HOSTS=[
+            "www.muckrock.com",
+            "www.foiamachine.org",
+            "www.unknownsite.org",
+        ],
         FLATPAGES_REDIRECTS={
             "www.muckrock.com": {
                 "about/how-we-work/": "https://help.muckrock.com/how-we-work-redirect",
             }
-        }
+        },
     )
     def test_no_redirect_unknown_site(self):
         request = self.factory.get("/about/how-we-work/")
@@ -67,11 +79,16 @@ class FlatpageRedirectMiddlewareTests(TestCase):
         self.assertEqual(new_response.status_code, 404)
 
     @override_settings(
+        ALLOWED_HOSTS=[
+            "www.muckrock.com",
+            "www.foiamachine.org",
+            "www.unknownsite.org",
+        ],
         FLATPAGES_REDIRECTS={
             "www.muckrock.com": {
                 "about/how-we-work/": "https://help.muckrock.com/how-we-work-redirect",
             }
-        }
+        },
     )
     def test_no_redirect_unknown_path(self):
         request = self.factory.get("/unknown/path/")

--- a/muckrock/core/tests/test_middleware.py
+++ b/muckrock/core/tests/test_middleware.py
@@ -1,5 +1,8 @@
-from django.test import TestCase, RequestFactory, override_settings
+# Django
 from django.http import HttpResponse, HttpResponseNotFound
+from django.test import RequestFactory, TestCase, override_settings
+
+# MuckRock
 from muckrock.core.middleware import FlatpageRedirectMiddleware
 
 

--- a/muckrock/core/tests/test_middleware.py
+++ b/muckrock/core/tests/test_middleware.py
@@ -1,0 +1,81 @@
+from django.test import TestCase, RequestFactory, override_settings
+from django.http import HttpResponse, HttpResponseNotFound
+from muckrock.core.middleware import FlatpageRedirectMiddleware
+
+@override_settings(ALLOWED_HOSTS=["www.muckrock.com", "www.foiamachine.org", "www.unknownsite.org"])
+class FlatpageRedirectMiddlewareTests(TestCase):
+    def setUp(self):
+        self.factory = RequestFactory()
+        self.middleware = FlatpageRedirectMiddleware(lambda request: HttpResponse())
+
+    @override_settings(
+        FLATPAGES_REDIRECTS={
+            "www.muckrock.com": {
+                "about/how-we-work/": "https://help.muckrock.com/how-we-work-redirect",
+            },
+            "www.foiamachine.org": {
+                "about/": "https://help.muckrock.com/foia-about-redirect",
+            },
+        }
+    )
+    def test_redirect_muckrock_domain(self):
+        # Request for a known route in the mocks above
+        request = self.factory.get("/about/how-we-work/")
+        request.META["HTTP_HOST"] = "www.muckrock.com"
+        response = HttpResponseNotFound()
+        redirected = self.middleware.process_response(request, response)
+        self.assertEqual(redirected.status_code, 301)
+        self.assertEqual(redirected.url, "https://help.muckrock.com/how-we-work-redirect")
+
+    @override_settings(
+        FLATPAGES_REDIRECTS={
+            "www.muckrock.com": {
+                "about/how-we-work/": "https://help.muckrock.com/how-we-work-redirect",
+            },
+            "www.foiamachine.org": {
+                "about/": "https://help.muckrock.com/foia-about-redirect",
+            },
+        }
+    )
+    def test_redirect_foiamachine_domain(self):
+        request = self.factory.get("/about/")
+        request.META["HTTP_HOST"] = "www.foiamachine.org"
+        response = HttpResponseNotFound()
+        redirected = self.middleware.process_response(request, response)
+        self.assertEqual(redirected.status_code, 301)
+        self.assertEqual(redirected.url, "https://help.muckrock.com/foia-about-redirect")
+
+    @override_settings(
+        FLATPAGES_REDIRECTS={
+            "www.muckrock.com": {
+                "about/how-we-work/": "https://help.muckrock.com/how-we-work-redirect",
+            }
+        }
+    )
+    def test_no_redirect_unknown_site(self):
+        request = self.factory.get("/about/how-we-work/")
+        request.META["HTTP_HOST"] = "www.unknownsite.org"
+        response = HttpResponseNotFound()
+        new_response = self.middleware.process_response(request, response)
+        self.assertEqual(new_response.status_code, 404)
+
+    @override_settings(
+        FLATPAGES_REDIRECTS={
+            "www.muckrock.com": {
+                "about/how-we-work/": "https://help.muckrock.com/how-we-work-redirect",
+            }
+        }
+    )
+    def test_no_redirect_unknown_path(self):
+        request = self.factory.get("/unknown/path/")
+        request.META["HTTP_HOST"] = "www.muckrock.com"
+        response = HttpResponseNotFound()
+        new_response = self.middleware.process_response(request, response)
+        self.assertEqual(new_response.status_code, 404)
+
+    def test_returns_original_response_if_not_404(self):
+        request = self.factory.get("/")
+        request.META["HTTP_HOST"] = "www.muckrock.com"
+        response = HttpResponse(status=200)
+        new_response = self.middleware.process_response(request, response)
+        self.assertEqual(new_response.status_code, 200)

--- a/muckrock/core/tests/test_middleware.py
+++ b/muckrock/core/tests/test_middleware.py
@@ -2,7 +2,10 @@ from django.test import TestCase, RequestFactory, override_settings
 from django.http import HttpResponse, HttpResponseNotFound
 from muckrock.core.middleware import FlatpageRedirectMiddleware
 
-@override_settings(ALLOWED_HOSTS=["www.muckrock.com", "www.foiamachine.org", "www.unknownsite.org"])
+
+@override_settings(
+    ALLOWED_HOSTS=["www.muckrock.com", "www.foiamachine.org", "www.unknownsite.org"]
+)
 class FlatpageRedirectMiddlewareTests(TestCase):
     def setUp(self):
         self.factory = RequestFactory()
@@ -25,7 +28,9 @@ class FlatpageRedirectMiddlewareTests(TestCase):
         response = HttpResponseNotFound()
         redirected = self.middleware.process_response(request, response)
         self.assertEqual(redirected.status_code, 301)
-        self.assertEqual(redirected.url, "https://help.muckrock.com/how-we-work-redirect")
+        self.assertEqual(
+            redirected.url, "https://help.muckrock.com/how-we-work-redirect"
+        )
 
     @override_settings(
         FLATPAGES_REDIRECTS={
@@ -43,7 +48,9 @@ class FlatpageRedirectMiddlewareTests(TestCase):
         response = HttpResponseNotFound()
         redirected = self.middleware.process_response(request, response)
         self.assertEqual(redirected.status_code, 301)
-        self.assertEqual(redirected.url, "https://help.muckrock.com/foia-about-redirect")
+        self.assertEqual(
+            redirected.url, "https://help.muckrock.com/foia-about-redirect"
+        )
 
     @override_settings(
         FLATPAGES_REDIRECTS={

--- a/muckrock/foiamachine/templates/foiamachine/base/base.html
+++ b/muckrock/foiamachine/templates/foiamachine/base/base.html
@@ -68,10 +68,9 @@ mixpanel.init("{{ mp_token }}", {debug:true});</script><!-- end Mixpanel -->
                 {% include 'foiamachine/icons/mascot.svg' %}
                 <p class="bold"><a href="{% host_url 'index' host 'foiamachine' %}">FOIA Machine</a></p>
                 <ul class="nostyle inline small">
-                    <li><a href="/about">About</a></li>
-                    <li><a href="/tos">Terms of Service</a></li>
-                    <li><a href="/privacy">Privacy Policy</a></li>
-                    <li><a href="/feedback">Feedback</a></li>
+                    <li><a href="https://help.muckrock.com/FOIA-Machine-19ef8892696381929466c66acc213128">About</a></li>
+                    <li><a href="https://www.muckrock.com/tos/">Terms of Service</a></li>
+                    <li><a href="https://www.muckrock.com/privacy-policy/">Privacy Policy</a></li>
                 </ul>
                 <p class="small grey">&copy; MuckRock Foundation, Inc. {% now "Y" %}</p>
             </main>

--- a/muckrock/settings/base.py
+++ b/muckrock/settings/base.py
@@ -232,7 +232,7 @@ MIDDLEWARE = (
     "django_hosts.middleware.HostsResponseMiddleware",
     "simple_history.middleware.HistoryRequestMiddleware",
     "daily_active_users.middleware.DailyActiveUserMiddleware",
-    "core.middleware.FlatpageRedirectMiddleware",
+    "muckrock.core.middleware.FlatpageRedirectMiddleware",
 )
 
 FLATPAGES_REDIRECTS = {

--- a/muckrock/settings/base.py
+++ b/muckrock/settings/base.py
@@ -232,7 +232,14 @@ MIDDLEWARE = (
     "django_hosts.middleware.HostsResponseMiddleware",
     "simple_history.middleware.HistoryRequestMiddleware",
     "daily_active_users.middleware.DailyActiveUserMiddleware",
+    "core.middleware.FlatpageRedirectMiddleware",
 )
+
+FLATPAGES_REDIRECTS = {
+    '/about/how-we-work/': 'https://help.muckrock.com/How-MuckRock-Works-19ef889269638140b169c8224a4c7c05',
+    '/api/': 'https://help.muckrock.com/API-19ef8892696381e88627c50e4ee90ed4',
+    '/faq/': 'https://help.muckrock.com/Frequently-Asked-Questions-19ef88926963814ea7e8e947b7fb6222',
+}
 
 INTERNAL_IPS = ("127.0.0.1",)
 

--- a/muckrock/settings/base.py
+++ b/muckrock/settings/base.py
@@ -236,14 +236,18 @@ MIDDLEWARE = (
 )
 
 FLATPAGES_REDIRECTS = {
-    'www.foiamachine.org': {
-        '/about/': 'https://help.muckrock.com/FOIA-Machine-19ef8892696381929466c66acc213128'
+    "www.foiamachine.org": {
+        "/about/": (
+            "https://help.muckrock.com/FOIA-Machine-19ef8892696381929466c66acc213128"
+        )
     },
-    'www.muckrock.com': {
-        '/about/how-we-work/': 'https://help.muckrock.com/How-MuckRock-Works-19ef889269638140b169c8224a4c7c05',
-        '/api/': 'https://help.muckrock.com/API-19ef8892696381e88627c50e4ee90ed4',
-        '/faq/': 'https://help.muckrock.com/Frequently-Asked-Questions-19ef88926963814ea7e8e947b7fb6222',
-    }
+    "www.muckrock.com": {
+        "/about/how-we-work/": (
+            "https://help.muckrock.com/19ef889269638140b169c8224a4c7c05"
+        ),
+        "/api/": "https://help.muckrock.com/19ef8892696381e88627c50e4ee90ed4",
+        "/faq/": ("https://help.muckrock.com/19ef88926963814ea7e8e947b7fb6222"),
+    },
 }
 
 INTERNAL_IPS = ("127.0.0.1",)

--- a/muckrock/settings/base.py
+++ b/muckrock/settings/base.py
@@ -236,9 +236,14 @@ MIDDLEWARE = (
 )
 
 FLATPAGES_REDIRECTS = {
-    '/about/how-we-work/': 'https://help.muckrock.com/How-MuckRock-Works-19ef889269638140b169c8224a4c7c05',
-    '/api/': 'https://help.muckrock.com/API-19ef8892696381e88627c50e4ee90ed4',
-    '/faq/': 'https://help.muckrock.com/Frequently-Asked-Questions-19ef88926963814ea7e8e947b7fb6222',
+    'www.foiamachine.org': {
+        '/about/': 'https://help.muckrock.com/FOIA-Machine-19ef8892696381929466c66acc213128'
+    },
+    'www.muckrock.com': {
+        '/about/how-we-work/': 'https://help.muckrock.com/How-MuckRock-Works-19ef889269638140b169c8224a4c7c05',
+        '/api/': 'https://help.muckrock.com/API-19ef8892696381e88627c50e4ee90ed4',
+        '/faq/': 'https://help.muckrock.com/Frequently-Asked-Questions-19ef88926963814ea7e8e947b7fb6222',
+    }
 }
 
 INTERNAL_IPS = ("127.0.0.1",)

--- a/muckrock/templates/crowdfund/widget.html
+++ b/muckrock/templates/crowdfund/widget.html
@@ -8,7 +8,7 @@
     <div>
       <span class="action" id="show-share">Share</span>
       <span class="action" id="show-embed">Embed</span>
-      <a class="action" href="/faq/#crowdfund" target="_blank">Help</a>
+      <a class="action" href="https://www.notion.so/muckrock/Frequently-Asked-Questions-19ef88926963814ea7e8e947b7fb6222?pvs=4#19ef889269638192b4f2e33e0d16ffa5" target="_blank">Help</a>
     </div>
   </header>
   <main>

--- a/muckrock/templates/foia/detail/actions.html
+++ b/muckrock/templates/foia/detail/actions.html
@@ -64,7 +64,7 @@
             We'll forward your request to {{ foia.agency }} and post any follow
             up material here. Note that some incoming records may take up to
             one business day to appear on your request. Check out
-            <a href="/about/how-we-work/">How MuckRock Works</a> for more on what
+            <a href="https://help.muckrock.com/19ef889269638140b169c8224a4c7c05">How MuckRock Works</a> for more on what
             to expect!
           </li>
         </ul>

--- a/muckrock/templates/homepage.html
+++ b/muckrock/templates/homepage.html
@@ -20,7 +20,7 @@
                     {% include 'lib/component/icon/create-request.svg' %}
                     <span class="label">File a Request</span>
                 </a>
-                <div class="call-to-action"><a href="{% url 'foia-root' %}">Explore filed requests</a> or <a href="/about/how-we-work/" id="learn-more">learn how it works</a>.</div>
+                <div class="call-to-action"><a href="{% url 'foia-root' %}">Explore filed requests</a> or <a href="https://help.muckrock.com/19ef889269638140b169c8224a4c7c05" id="learn-more">learn how it works</a>.</div>
             </div>
             <ul class="stats banner-container">
 			{% with request_count=stats.request_count agency_count=stats.agency_count completed_count=stats.completed_count page_count=stats.page_count %}

--- a/muckrock/templates/nav/footer.html
+++ b/muckrock/templates/nav/footer.html
@@ -34,9 +34,9 @@
                 <ul>
                     <li><a href="/about/">About Us</a></li>
                     <li><a href="/staff/">Staff</a></li>
-                    <li><a href="/faq/">FAQ</a></li>
+                    <li><a href="https://help.muckrock.com/19ef88926963814ea7e8e947b7fb6222" target="_blank">FAQ</a></li>
+                    <li><a href="https://help.muckrock.com/19ef8892696381e88627c50e4ee90ed4" target="_blank">API</a></li>
                     <li><a href="/news/editorial-policy/">Editorial Policy</a></li>
-                    <li><a href="/api/">API</a></li>
                     <li><a href="/privacy-policy/">Privacy Policy</a></li>
                     <li><a href="/tos/">Terms of Service</a></li>
                     <li><a href="/financial/">Financials</a></li>

--- a/muckrock/templates/nav/header.html
+++ b/muckrock/templates/nav/header.html
@@ -126,8 +126,8 @@
                 <li class="separator"><a class="nav-item" href="{% url 'donate' %}">Donate</a></li>
                 <li><a class="nav-item" href="/about/">About Us</a></li>
                 <li><a class="nav-item" href="/staff/">Staff</a></li>
-                <li><a class="nav-item" href="/faq/">FAQ</a></li>
-                <li><a class="nav-item" href="/api/">API</a></li>
+                <li><a class="nav-item" href="https://help.muckrock.com/19ef88926963814ea7e8e947b7fb6222">FAQ</a></li>
+                <li><a class="nav-item" href="https://help.muckrock.com/19ef8892696381e88627c50e4ee90ed4">API</a></li>
               </ul>
             </li>
           </ul>


### PR DESCRIPTION
1. Creates a setting for configuring flatpage redirects, and middleware for redirecting matching flatpage URLs. Closes #1972.
1. Updates MuckRock links to point to Notion help site
1. Updates FOIA Machine footer links and adds help page redirect. Closes #1973.

Test on staging:
- [muckrock-staging.herokuapp.com](https://muckrock-staging.herokuapp.com/)
- [staging.foiamachine.org](https://staging.foiamachine.org/)