### PR TITLE
Fix routing for /accounts/ to give intent, since /signup/ doesn't exist

### DIFF
--- a/muckrock/accounts/urls.py
+++ b/muckrock/accounts/urls.py
@@ -13,16 +13,15 @@ from django.views.generic import RedirectView
 from muckrock.accounts import views
 
 urlpatterns = [
-    re_path(r"^$", views.AccountsView.as_view(), name="accounts"),
     re_path(
         r"^upgrade/$", views.AccountsUpgradeView.as_view(), name="accounts-upgrade"
     ),
     re_path(
-        r"^signup/$",
+        r"^accounts/$",
         RedirectView.as_view(
             url=settings.SQUARELET_URL + "/accounts/signup/?intent=muckrock"
         ),
-        name="accounts-signup",
+        name="accounts",
     ),
     re_path(
         r"^login/$",


### PR DESCRIPTION
Now when someone clicks on the sign up button on muckrock, which routes them to /accounts/, it will send their intent to Squarelet. 