### PR TITLE
fix get help form, closes #2003

### DIFF
--- a/muckrock/assets/scss/view/detail/_foia.scss
+++ b/muckrock/assets/scss/view/detail/_foia.scss
@@ -692,6 +692,10 @@ $request-breakpoint: 768px;
   margin-right: 1em;
 }
 
+.actions form {
+  display: inline;
+}
+
 .request-organizations {
   display: none;
 }

--- a/muckrock/foia/forms/detail.py
+++ b/muckrock/foia/forms/detail.py
@@ -167,12 +167,6 @@ class FOIAFlagForm(forms.Form):
                 + PUBLIC_FLAG_CATEGORIES
             )
 
-    def clean(self):
-        """Must fill in one of the fields"""
-        cleaned_data = super().clean()
-        if not cleaned_data.get("category") and not cleaned_data.get("text"):
-            raise forms.ValidationError("Must select a category or provide text")
-
 
 class FOIAContactUserForm(forms.Form):
     """Form for contacting the owner of a request"""

--- a/muckrock/foia/views/detail_actions.py
+++ b/muckrock/foia/views/detail_actions.py
@@ -154,6 +154,8 @@ def flag(request, foia):
         messages.success(request, "Problem succesfully reported")
         if request.user.is_authenticated:
             new_action(request.user, "flagged", target=foia)
+    else:
+        messages.error(request, f"Error: {form.errors}")
 
     return _get_redirect(request, foia)
 

--- a/muckrock/templates/foia/detail/actions.html
+++ b/muckrock/templates/foia/detail/actions.html
@@ -113,10 +113,10 @@
       {% include "foia/detail/file_download.html" %}
     {% endif %}
 
-    <form method="post" novalidate>
-      {% csrf_token %}
-      {% for action in user_actions %}
-        {% if action.test %}
+    {% for action in user_actions %}
+      {% if action.test %}
+        <form method="post">
+          {% csrf_token %}
           {% if action.link %}
             <a
               href="{{ action.link }}"
@@ -148,9 +148,9 @@
               <span class="close-modal button">Close</span>
             </div>
           {% endif %}
-        {% endif %}
-      {% endfor %}
-    </form>
+        </form>
+      {% endif %}
+    {% endfor %}
   </section>
 
 {% else %} {# unauthenticated #}


### PR DESCRIPTION

The modals were all in one form with `novalidate` set - I put each one into its own form and turned validation on, so the browser will enforce filling out the form.  If you do manage to submit it incorrectly, it will also show an error message now.