### PR TITLE
restrict anonymous users to the first 10 pages of results

### DIFF
--- a/muckrock/core/views.py
+++ b/muckrock/core/views.py
@@ -259,6 +259,25 @@ class MRListView(PaginationMixin, TitleMixin, ListView):
 
     template_name = "base_list.html"
 
+    def get(self, request, *args, **kwargs):
+        try:
+            page = int(request.GET.get("page", 1))
+        except ValueError:
+            page = 1
+        if request.user.is_anonymous and page > 10:
+            context = {
+                "error": "Please create an account and log in to see "
+                "results for pages beyond the first 10"
+            }
+            return render(
+                request,
+                "base_list.html",
+                context,
+                status=401,
+            )
+
+        return super().get(request, *args, **kwargs)
+
 
 class MROrderedListView(OrderedSortMixin, MRListView):
     """Adds ordering to a list view."""

--- a/muckrock/templates/base_list.html
+++ b/muckrock/templates/base_list.html
@@ -92,7 +92,9 @@
           {% include 'lib/component/pagination.html' %}
         {% else %}
           {% block empty %}
-            {% if request.GET %}
+            {% if error %}
+              <p class="empty">{{ error }}</p>
+            {% elif request.GET %}
               <p class="empty">No results given this filter.</p>
             {% else %}
               <p class="empty">No Results</p>


### PR DESCRIPTION
This restricts anonymous users to the first 10 pages of results.  I see many bots in the logs going through all pages of results, I doubt actual users are often going past page 10, and they can sign up for a free account if they need to.