### PR TITLE
improve og:description tag to show on single line

### DIFF
--- a/muckrock/templates/foia/detail/open_graph.html
+++ b/muckrock/templates/foia/detail/open_graph.html
@@ -4,14 +4,6 @@
   <meta property="og:title" content="{{ foia.title }}" />
   <meta property="og:type" content="website" />
   <meta property="og:url" content="{{ request.build_absolute_uri }}" />
-  <meta property="og:description" content="{{ foia.user.profile.full_name }}
-    {% if foia.datetime_done %}made{% else %}is making{% endif %}
-    this request
-    {% if foia.agency %}
-      to {{ foia.agency.name }} of
-      {% if foia.jurisdiction.name == "United States of America" %}the {% endif %}
-      {{ foia.jurisdiction.name }}.
-    {% endif %}"
-    />
+  <meta property="og:description" content="{{ foia.user.profile.full_name }} {% if foia.datetime_done %}made{% else %}is making{% endif %} this request{% if foia.agency %} to {{ foia.agency.name }} of {% if foia.jurisdiction.name == "United States of America" %}the {% endif %}{{ foia.jurisdiction.name }}.{% endif %}"/>
   <meta property="og:site_name" content="MuckRock" />
 {% endcache %}


### PR DESCRIPTION
This is a small change to display the og:description tag on a single line without linebreaks, which I think improves the display of embedded web cards.

The way it currently shows with newlines in the tag:
<img width="1228" height="448" alt="Screenshot From 2025-07-22 10-32-25" src="https://github.com/user-attachments/assets/14e5224a-efd4-4bc1-8e43-f041b736d8a2" />
