### PR TITLE
Restore editing to PrettyJSONWidget

### DIFF
--- a/muckrock/core/admin.py
+++ b/muckrock/core/admin.py
@@ -35,9 +35,9 @@ class PrettyJSONWidget(widgets.Textarea):
                 return ""
             else:
                 data = json.loads(value)
-            
+
             pretty = json.dumps(data, indent=2, sort_keys=True)
-            
+
             # these lines will try to adjust size of TextArea to fit to content
             row_lengths = [len(r) for r in pretty.split("\n")]
             self.attrs["rows"] = min(max(len(row_lengths) + 2, 10), 30)

--- a/muckrock/core/admin.py
+++ b/muckrock/core/admin.py
@@ -25,7 +25,6 @@ from muckrock.news.models import Article
 
 # https://stackoverflow.com/questions/48145992/showing-json-field-in-django-admin
 # https://github.com/MuckRock/documentcloud/blob/master/documentcloud/addons/admin.py#L26-L38
-# FIXME: This makes the field read-only.
 class PrettyJSONWidget(widgets.Textarea):
     def format_value(self, value):
         try:

--- a/muckrock/core/admin.py
+++ b/muckrock/core/admin.py
@@ -25,16 +25,25 @@ from muckrock.news.models import Article
 
 # https://stackoverflow.com/questions/48145992/showing-json-field-in-django-admin
 # https://github.com/MuckRock/documentcloud/blob/master/documentcloud/addons/admin.py#L26-L38
+# FIXME: This makes the field read-only.
 class PrettyJSONWidget(widgets.Textarea):
     def format_value(self, value):
         try:
-            value = json.dumps(json.loads(value), indent=2, sort_keys=True)
+            # Accept Python objects and JSON strings
+            if isinstance(value, (dict, list)):
+                data = value
+            elif value in (None, ""):
+                return ""
+            else:
+                data = json.loads(value)
+            
+            pretty = json.dumps(data, indent=2, sort_keys=True)
+            
             # these lines will try to adjust size of TextArea to fit to content
-            row_lengths = [len(r) for r in value.split("\n")]
+            row_lengths = [len(r) for r in pretty.split("\n")]
             self.attrs["rows"] = min(max(len(row_lengths) + 2, 10), 30)
             self.attrs["cols"] = min(max(max(row_lengths) + 2, 40), 120)
-            self.attrs["readonly"] = True
-            return value
+            return pretty
         except Exception:  # pylint: disable=broad-except
             return super().format_value(value)
 


### PR DESCRIPTION
The `PrettyJSONWidget` had a `readonly` attribute set by accident, so the field is now editable.

While working on it, I expanded its data loading to handle Python objects in addition to JSON strings.