### PR TITLE
Enhances `SingletonModelAdmin` version control

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ celerybeat-schedule
 .envrc
 .vscode
 /src
+CLAUDE.md

--- a/muckrock/core/admin.py
+++ b/muckrock/core/admin.py
@@ -15,6 +15,7 @@ from django.utils.translation import gettext as _
 import json
 
 # Third Party
+from reversion.admin import VersionAdmin
 from simple_history import register
 from simple_history.admin import SimpleHistoryAdmin
 
@@ -90,9 +91,9 @@ class FlatpageAdmin(SimpleHistoryAdmin, flatpages.admin.FlatPageAdmin):
         return render_flatpage(request, flatpage)
 
 
-class SingletonModelAdmin(admin.ModelAdmin):
+class SingletonModelAdmin(VersionAdmin):
     """
-    Admin class for singleton models.
+    Admin class for singleton models with version control.
     """
 
     singleton_instance_id = 1

--- a/muckrock/core/models.py
+++ b/muckrock/core/models.py
@@ -16,6 +16,9 @@ from django.db.models import (
     TextField,
 )
 
+# Third Party
+import reversion
+
 
 # This is in django but does not support intervals until django 2.0
 class ExtractDay(Func):
@@ -63,6 +66,7 @@ class SingletonModel(Model):
         return getattr(obj, field_name, default_value)
 
 
+@reversion.register()
 class HomePage(SingletonModel):
     about_heading = CharField(
         max_length=255,
@@ -106,6 +110,7 @@ class HomePage(SingletonModel):
         return "Home Page"
 
 
+@reversion.register()
 class FeaturedProjectSlot(Model):
     homepage = ForeignKey(
         HomePage, on_delete=CASCADE, related_name="featured_project_slots"


### PR DESCRIPTION
Closes #2043 by enhancing the `SingletonModelAdmin` with version control through `django-reversion` and registering the `HomePage` and `FeaturedProjectSlot`. This allows for more granular version control on edits to the HomePage.

I applied this change with assistance from [Claude Code](https://www.anthropic.com/claude-code). After the session, I saved some local instructions to a `CLAUDE.md` file. I've excluded that file from version control.