### PR TITLE
Migrate to sentry-sdk for Sentry handling.

### DIFF
--- a/muckrock/accounts/tasks.py
+++ b/muckrock/accounts/tasks.py
@@ -15,10 +15,6 @@ import logging
 import os
 from datetime import date, datetime, time, timedelta
 
-# Third Party
-from raven import Client
-from raven.contrib.celery import register_logger_signal, register_signal
-
 # MuckRock
 from muckrock.accounts.models import Statistics
 from muckrock.accounts.utils import mailchimp_donor_tag
@@ -51,11 +47,6 @@ from muckrock.task.models import (
 )
 
 logger = logging.getLogger(__name__)
-
-client = Client(os.environ.get("SENTRY_DSN"))
-register_logger_signal(client)
-register_signal(client)
-
 
 @shared_task
 def store_statistics():

--- a/muckrock/accounts/tasks.py
+++ b/muckrock/accounts/tasks.py
@@ -12,7 +12,6 @@ from django.utils import timezone
 
 # Standard Library
 import logging
-import os
 from datetime import date, datetime, time, timedelta
 
 # MuckRock
@@ -47,6 +46,7 @@ from muckrock.task.models import (
 )
 
 logger = logging.getLogger(__name__)
+
 
 @shared_task
 def store_statistics():

--- a/muckrock/agency/tasks.py
+++ b/muckrock/agency/tasks.py
@@ -5,7 +5,6 @@ from celery import shared_task
 
 # Standard Library
 import csv
-import os
 
 # Third Party
 from smart_open.smart_open_lib import smart_open
@@ -15,6 +14,7 @@ from muckrock.agency.importer import CSVReader, Importer
 from muckrock.core.tasks import AsyncFileDownloadTask
 from muckrock.foia.models import FOIARequest
 from muckrock.task.models import ReviewAgencyTask
+
 
 @shared_task
 def stale():

--- a/muckrock/agency/tasks.py
+++ b/muckrock/agency/tasks.py
@@ -8,8 +8,6 @@ import csv
 import os
 
 # Third Party
-from raven import Client
-from raven.contrib.celery import register_logger_signal, register_signal
 from smart_open.smart_open_lib import smart_open
 
 # MuckRock
@@ -17,11 +15,6 @@ from muckrock.agency.importer import CSVReader, Importer
 from muckrock.core.tasks import AsyncFileDownloadTask
 from muckrock.foia.models import FOIARequest
 from muckrock.task.models import ReviewAgencyTask
-
-client = Client(os.environ.get("SENTRY_DSN"))
-register_logger_signal(client)
-register_signal(client)
-
 
 @shared_task
 def stale():

--- a/muckrock/foia/tasks.py
+++ b/muckrock/foia/tasks.py
@@ -41,8 +41,6 @@ from documentcloud.exceptions import DocumentCloudError
 from documentcloud.toolbox import grouper
 from phaxio import PhaxioApi
 from phaxio.exceptions import PhaxioError
-from raven import Client
-from raven.contrib.celery import register_logger_signal, register_signal
 from zipstream import ZIP_DEFLATED, ZipFile
 
 # MuckRock
@@ -72,10 +70,6 @@ from muckrock.task.pdf import LobPDF
 foia_url = r"(?P<jurisdiction>[\w\d_-]+)-(?P<jidx>\d+)/(?P<slug>[\w\d_-]+)-(?P<idx>\d+)"
 
 logger = logging.getLogger(__name__)
-
-client = Client(os.environ.get("SENTRY_DSN"))
-register_logger_signal(client)
-register_signal(client)
 
 lob.api_key = settings.LOB_SECRET_KEY
 

--- a/muckrock/settings/base.py
+++ b/muckrock/settings/base.py
@@ -13,8 +13,10 @@ import urllib.parse
 from collections import OrderedDict
 from datetime import date
 
+# Third Party
 # Sentry
 import sentry_sdk
+
 
 def boolcheck(setting):
     """Turn env var into proper bool"""
@@ -23,10 +25,11 @@ def boolcheck(setting):
     else:
         return bool(setting)
 
+
 sentry_sdk.init(
     dsn=os.environ.get("SENTRY_DSN", ""),
     send_default_pii=True,
- )
+)
 
 
 # monkey patch celery to prevent Timed out waiting for UP message errors
@@ -485,7 +488,7 @@ MONTHLY_REQUESTS = {
 LOGGING = {
     "version": 1,
     "disable_existing_loggers": True,
-    "root": {"level": "WARNING", "handlers": ["console", "sentry"]},
+    "root": {"level": "WARNING", "handlers": ["console"]},
     "formatters": {
         "verbose": {
             "format": "%(levelname)s %(asctime)s %(module)s %(process)d "
@@ -514,18 +517,18 @@ LOGGING = {
     "loggers": {
         "django": {"handlers": ["null"], "propagate": True, "level": "INFO"},
         "django.request": {
-            "handlers": ["console", "sentry"],
+            "handlers": ["console"],
             "level": "WARNING",
             "propagate": False,
         },
         "muckrock": {
-            "handlers": ["console", "sentry"],
+            "handlers": ["console"],
             "level": "INFO",
             "propagate": False,
         },
         "django.db.backends": {
             "level": "ERROR",
-            "handlers": ["console", "sentry"],
+            "handlers": ["console"],
             "propagate": False,
         },
         "dogslow": {"level": "WARNING", "handlers": ["dogslow"]},

--- a/muckrock/settings/base.py
+++ b/muckrock/settings/base.py
@@ -13,6 +13,8 @@ import urllib.parse
 from collections import OrderedDict
 from datetime import date
 
+# Sentry
+import sentry_sdk
 
 def boolcheck(setting):
     """Turn env var into proper bool"""
@@ -20,6 +22,11 @@ def boolcheck(setting):
         return setting.lower() in ("yes", "true", "t", "1")
     else:
         return bool(setting)
+
+sentry_sdk.init(
+    dsn=os.environ.get("SENTRY_DSN", ""),
+    send_default_pii=True,
+ )
 
 
 # monkey patch celery to prevent Timed out waiting for UP message errors
@@ -281,7 +288,6 @@ INSTALLED_APPS = (
     "localflavor",
     "mathfilters",
     "news_sitemaps",
-    "raven.contrib.django",
     "rest_framework",
     "rest_framework.authtoken",
     "reversion",
@@ -500,14 +506,9 @@ LOGGING = {
             "filters": ["require_debug_false"],
             "class": "django.utils.log.AdminEmailHandler",
         },
-        "sentry": {
-            "level": "ERROR",
-            "class": "raven.contrib.django.handlers.SentryHandler",
-            "filters": ["require_debug_false"],
-        },
         "dogslow": {
             "level": "WARNING",
-            "class": "raven.contrib.django.handlers.SentryHandler",
+            "class": "sentry_sdk.integrations.logging.EventHandler",
         },
     },
     "loggers": {
@@ -525,12 +526,6 @@ LOGGING = {
         "django.db.backends": {
             "level": "ERROR",
             "handlers": ["console", "sentry"],
-            "propagate": False,
-        },
-        "raven": {"level": "WARNING", "handlers": ["console"], "propagate": False},
-        "sentry.errors": {
-            "level": "WARNING",
-            "handlers": ["console"],
             "propagate": False,
         },
         "dogslow": {"level": "WARNING", "handlers": ["dogslow"]},

--- a/pip/requirements.in
+++ b/pip/requirements.in
@@ -69,12 +69,12 @@ python-Levenshtein==0.12.2 # fuzzy string matching for FM agency import
 python-dateutil # Used for relative time deltas
 python-documentcloud # for uploading to documentcloud
 python-redis-lock[django] # use a redis cache with a locking mechanism
-raven # Sentry integration
 redis # Redis integration - for use with celery
 reportlab # Used for adding text to PDFs for form filling in
 requests # HTTP for humans
 rules # Rule based permissions
 scout-apm # performance monitoring
+sentry-sdk[django, celery] # Sentry integration for exception monitoring
 simplejson # json decoder for requests
 smart-open # Use for streaming files from S3
 smartypants # Used for typographically-correct quotes

--- a/pip/requirements.txt
+++ b/pip/requirements.txt
@@ -69,11 +69,13 @@ celery==5.4.0
     # via
     #   -r pip/requirements.in
     #   django-celery-email
+    #   sentry-sdk
 certifi==2017.4.17
     # via
     #   httpcore
     #   httpx
     #   requests
+    #   sentry-sdk
     #   urllib3
 cffi==1.17.1
     # via cryptography
@@ -157,6 +159,7 @@ django==4.2
     #   drf-spectacular
     #   easy-thumbnails
     #   jsonfield
+    #   sentry-sdk
 django-activity-stream==1.4.2
     # via -r pip/requirements.in
 django-anymail[mailgun]==9.1
@@ -487,8 +490,6 @@ pyyaml==6.0.1
     #   python-documentcloud
 ratelimit==2.2.1
     # via python-documentcloud
-raven==6.10.0
-    # via -r pip/requirements.in
 rcssmin==1.1.1
     # via django-compressor
 redis==3.5.3
@@ -545,6 +546,8 @@ scout-apm==2.16.2
     # via -r pip/requirements.in
 scrapelib==2.2.0
     # via govqa
+sentry-sdk[celery,django]==2.35.2
+    # via -r pip/requirements.in
 simplejson==3.16.0
     # via -r pip/requirements.in
 six==1.15.0
@@ -640,6 +643,7 @@ urllib3[secure]==1.26.16
     #   requests
     #   scout-apm
     #   scrapelib
+    #   sentry-sdk
 urllib3-secure-extra==0.1.0
     # via urllib3
 vine==5.1.0


### PR DESCRIPTION
This is related to #2048 
Raven is deprecated as of 2023 and doesn't support 3.11. We need to upgrade to sentry-sdk, as noted in the issue. 

I used this migration guide:
https://docs.sentry.io/platforms/python/migration/raven-to-sentry-sdk/
and took a look at these:
https://docs.sentry.io/platforms/python/integrations/django/
https://docs.sentry.io/platforms/python/integrations/celery/

It seems like the defaults should automatically hook into our app and the only custom handling we want is for dogslow. 

There is an important note in the migration guide about [sensitive data](https://docs.sentry.io/platforms/python/migration/raven-to-sentry-sdk/#filtering-sensitive-data) that we will want to review and figure out how we want to handle. We may consider using before_send to filter out Stripe errors. 
