### PR TITLE
Reorder buildpacks

### DIFF
--- a/app.json
+++ b/app.json
@@ -20,9 +20,9 @@
   ],
   "buildpacks": [
     { "url": "https://github.com/SectorLabs/heroku-buildpack-git-submodule" },
+    { "url": "heroku/nodejs" },
     { "url": "heroku/python" },
     { "url": "https://github.com/heroku/heroku-buildpack-nginx" },
-    { "url": "heroku/nodejs" },
     { "url": "heroku-community/cli"}
   ],
   "scripts": {


### PR DESCRIPTION
The `collectstatic` command may fail if there are changes to asset files and the  Node.js buildpack hasn't run first.