### PR TITLE
Pass certified parameter to prepare_snail_mail

### DIFF
--- a/muckrock/portal/portals/nextrequest.py
+++ b/muckrock/portal/portals/nextrequest.py
@@ -74,7 +74,7 @@ class NextRequestPortal(PortalAutoReceiveMixin, ManualPortal):
             )
         elif comm.category == "p":
             # Payments are still always mailed
-            prepare_snail_mail.delay(comm.pk, False, extra)
+            prepare_snail_mail.delay(comm.pk, False, extra, None)
         else:
             super().send_msg(comm, reason="Unknown category of send message", **kwargs)
 

--- a/muckrock/task/views.py
+++ b/muckrock/task/views.py
@@ -293,6 +293,7 @@ class SnailMailTaskList(TaskList):
                 task.communication.pk,
                 task.switch,
                 {"amount": task.amount},
+                None,
                 force=True,
             )
             return task


### PR DESCRIPTION
Closes #2099

The `prepare_snail_mail` task requires a `certified` parameter, but two call sites were missing it:
- `task/views.py` (snail mail task lob button)
- `portal/portals/nextrequest.py` (payment handling)

Adds `None` (regular mail) as the certified parameter in both locations.