### PR TITLE
Add descriptive message to ValueError in fetch_raw_email task

### DIFF
--- a/muckrock/foia/querysets.py
+++ b/muckrock/foia/querysets.py
@@ -524,7 +524,7 @@ class RawEmailQuerySet(models.QuerySet):
                 "Fetching raw emails: message_id: %s - items not found, will retry",
                 message_id,
             )
-            raise ValueError
+            raise ValueError(f"No stored emails found for message_id: {message_id}")
         url = items[0]["storage"]["url"]
         response = requests.get(
             url,


### PR DESCRIPTION
Fixes #2097

The `fetch_raw_email` task raises a bare `ValueError` when no stored emails are found in Mailgun, providing no diagnostic context when the task fails after exhausting retries.

Adds a descriptive message including the `message_id` to help with debugging in Sentry.