### PR TITLE
ci: remove redundant AWS and PG env vars from workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,8 +19,6 @@ env:
   JWT_VERIFYING_KEY: 'tk'
   OPENAI_API_KEY: 'tk'
   SQUARELET_SECRET: ${{secrets.SQUARELET_SECRET}}
-  AWS_ACCESS_KEY_ID: ${{secrets.AWS_ACCESS_KEY_ID}}
-  AWS_SECRET_ACCESS_KEY: ${{secrets.AWS_SECRET_ACCESS_KEY}}
 
 jobs:
   check:
@@ -124,7 +122,4 @@ jobs:
       - name: Pytest
         run: pytest muckrock
         env:
-          # use the credentials for the service container
-          PG_USER: ${{secrets.PG_USER}}
-          PG_PASSWORD: ${{secrets.PG_PASSWORD}}
           DATABASE_URL: postgresql://test:postgres@localhost:5432/muckrock


### PR DESCRIPTION
Removes AWS credentials and PG user/password environment variables from the CI workflow that are redundant or unused.

## Changes
- Removed AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY from workflow env vars
- Removed PG_USER and PG_PASSWORD from pytest step env vars

## Rationale

### AWS credentials
The test settings already override these with placeholder values at [muckrock/settings/test.py:55-56](https://github.com/MuckRock/muckrock/blob/master/muckrock/settings/test.py#L55-L56):
```python
# don't use real AWS credentials for tests
AWS_ACCESS_KEY_ID = "placeholder"
AWS_SECRET_ACCESS_KEY = "placeholder"
```

### PG credentials
PG_USER and PG_PASSWORD are not used because the database configuration extracts credentials from DATABASE_URL instead. The workflow uses `DJANGO_SETTINGS_MODULE=muckrock.settings.test`, which inherits from base.py where DATABASE_URL is parsed at [muckrock/settings/base.py:589-604](https://github.com/MuckRock/muckrock/blob/master/muckrock/settings/base.py#L589-L604):

```python
url = urllib.parse.urlparse(
    os.environ.get("DATABASE_URL", "postgres://vagrant@localhost/muckrock")
)

DATABASES = {
    "default": {
        "NAME": url.path[1:],
        "USER": url.username,      # ← from DATABASE_URL, not PG_USER
        "PASSWORD": url.password,  # ← from DATABASE_URL, not PG_PASSWORD
        "HOST": url.hostname,
        "PORT": url.port,
        ...
    }
}
```

Since DATABASE_URL is hardcoded at [.github/workflows/test.yml:125](https://github.com/MuckRock/muckrock/blob/master/.github/workflows/test.yml#L125) with the correct postgres service credentials (`postgresql://test:postgres@localhost:5432/muckrock`), the separate PG_USER and PG_PASSWORD env vars are redundant.

Note: PG_USER/PG_PASSWORD are only used by the codeship.py settings file, which is not used by this workflow.

## Impact
This partially addresses issue #2111 by reducing the number of repository secrets required for CI to pass. External contributors forking the repository won't need to set these specific secrets to run tests.