### PR TITLE
Add fallback SECRET_KEY for fork PR CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ on:
       - master
 
 env:
-  SECRET_KEY: ${{secrets.SECRET_KEY}}
+  SECRET_KEY: ${{ secrets.SECRET_KEY || 'ci-test-key' }}
   DJANGO_SETTINGS_MODULE: muckrock.settings.test
   MUCKROCK_TOKEN: token
   STRIPE_SECRET_KEY: ${{secrets.STRIPE_SECRET_KEY}}


### PR DESCRIPTION
Fixes #2119

Fork PRs fail CI because they can't access upstream secrets.