### PR TITLE
Pins setuptools in Dockerfile, fixes inv pip-compile task. 

### DIFF
--- a/compose/local/django/Dockerfile
+++ b/compose/local/django/Dockerfile
@@ -56,7 +56,7 @@ COPY ./pip /pip
 #RUN --mount=type=cache,target=/root/.cache/pip pip install -r /pip/requirements.txt
 #RUN --mount=type=cache,target=/root/.cache/pip pip install -r /pip/dev-requirements.txt
 # Update setuptools
-RUN pip install --upgrade setuptools>=61.0.0
+RUN pip install --upgrade setuptools==80.9.0
 # Use pre-built wheel
 RUN pip install wheel
 # Install requirements

--- a/local.yml
+++ b/local.yml
@@ -1,4 +1,3 @@
-version: '3.8'
 name: ${COMPOSE_PROJECT_NAME:-muckrock}
 
 volumes:

--- a/tasks.py
+++ b/tasks.py
@@ -251,14 +251,13 @@ def pip_compile(c, upgrade=False, package=None):
         upgrade_flag = "--upgrade"
     else:
         upgrade_flag = ""
-    c.run(
-        DJANGO_RUN.format(
-            cmd="pip-compile {upgrade_flag} pip/requirements.in &&"
-            "pip-compile {upgrade_flag} pip/dev-requirements.in".format(
-                upgrade_flag=upgrade_flag
-            )
-        )
-    )
+
+    c.run(DJANGO_RUN.format(
+        cmd=f"pip-compile --resolver=backtracking {upgrade_flag} pip/requirements.in"
+    ))
+    c.run(DJANGO_RUN.format(
+        cmd=f"pip-compile --resolver=backtracking {upgrade_flag} pip/dev-requirements.in"
+    ))
 
 
 @task


### PR DESCRIPTION
Should close #2052 

This pins us to setuptools == 80.9.0, last one before pkg_resources gets removed. 

In fixing this I also found that our current formatting for inv pip-compile means that the second command after && seems to run outside the docker container. Only discovered this because I recently removed a bunch of stuff from my local  system Python environment including pip-tools. So when I saw a warning that it couldn't find it, that made no sense. 

Finally, I removed the "version" key from our .yml file as docker was throwing us warnings to tell us it was deprecated when I ran inv pip-compile. Now you should be able to inv build with this new file which will install setuptools ==80.9.0, and run inv pip-compile and inv pip-compile --upgrade without issues. 

