### PR TITLE
Set configurable Vite base for dynamic imports

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -6,7 +6,7 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 export default defineConfig({
-  base: "/static/",
+  base: process.env.VITE_ASSET_BASE || "/static/",
   build: {
     manifest: "manifest.json",
     outDir: path.resolve(__dirname, "muckrock/assets/dist"),


### PR DESCRIPTION
Hot fix for dynamic asset loading issue

Requires a `VITE_ASSET_BASE` env var to be set in our Heroku environments at build time.