### PR TITLE
Fix typos across codebase and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Note: If dev.muckrock.com/admin (without a trailing /) does not work and throws 
 
 ## Docker info
 
-The development environment is managed via [docker][docker] and [docker compose][docker compose].  Please read up on them if you are unfmiliar with them.  The docker compose file is `local.yml`.  If you would like to run `docker compose` commands directly, please run `export COMPOSE_FILE=local.yml` so you don't need to specify it in every command.
+The development environment is managed via [docker][docker] and [docker compose][docker compose].  Please read up on them if you are unfamiliar with them.  The docker compose file is `local.yml`.  If you would like to run `docker compose` commands directly, please run `export COMPOSE_FILE=local.yml` so you don't need to specify it in every command.
 
 The containers which are run include the following:
 
@@ -78,7 +78,7 @@ This is the [Django][django] application
 [Redis][redis] is an in-memory datastore, used as a message broker for Celery as well as a cache backend for Django.
 
 * Celery Worker
-[Celery][celery] is a distrubuted task queue for Python, used to run background tasks from Django.  The worker is responsible for running the tasks.
+[Celery][celery] is a distributed task queue for Python, used to run background tasks from Django.  The worker is responsible for running the tasks.
 
 * Celery Beat
 The celery beat image is responsible for queueing up periodic celery tasks.
@@ -117,7 +117,7 @@ Both linting and formatting are checked on CodeShip.  Please ensure your code is
 `inv up` will start all containers in the background.
 `inv runserver` will run the Django server in the foreground.  Be careful to not have multiple Django servers running at once.  Running the server in the foreground is mainly useful for situations where you would like to use an interactive debugger within your application code.
 `inv shell` will run an interactive python shell within the Django environment.
-`inv sh` will run a bash shell within the Django docker comtainer.
+`inv sh` will run a bash shell within the Django docker container.
 `inv dbshell` will run a postgresql shell.
 `inv manage` will allow you to easily run Django manage.py commands.
 - `inv manage migrate` to migrate database
@@ -128,13 +128,13 @@ Both linting and formatting are checked on CodeShip.  Please ensure your code is
 
 Python dependencies are managed via [pip-tools][pip-tools].  This allows us to keep all of the python dependencies (including underling dependencies) pinned, to allow for consistent execution across development and production environments.
 
-The corresponding files are kept in the `pip` folder.  There are `requirements` and `dev-requirements` files.  `requirements` will be installed in all environments, while `dev-requirements` will only be installed for local development environments.  It can be used for code only needed during develpoment, such as testing.  For each environment there is an `.in` file and a `.txt` file.  The `.in` file is the input file - you list your direct dependencies here.  You may specify version constraints here, but do not have to.
+The corresponding files are kept in the `pip` folder.  There are `requirements` and `dev-requirements` files.  `requirements` will be installed in all environments, while `dev-requirements` will only be installed for local development environments.  It can be used for code only needed during development, such as testing.  For each environment there is an `.in` file and a `.txt` file.  The `.in` file is the input file - you list your direct dependencies here.  You may specify version constraints here, but do not have to.
 
 Running `inv pip-compile` will compile the `.in` files to the corresponding `.txt` files.  This will pin all of the dependencies, and their dependencies, to the latest versions that meet any constraints that have been put on them.  You should run this command if you need to add any new dependencies to an `.in` files.  Please keep the `.in` files sorted.  After running `inv pip-compile`, you will need to run `inv build` to rebuild the docker images with the new dependencies included.
 
 ## FOIAMachine
 
-FOIAMachine is our free FOIA filing tool, that allows you to track your requests while requiring you to manually handle all of the message sending and receiving.  It is run off of the same code base as MuckRock.  To access it, set `dev.foiamachine.org` to point to localhost - `sudo echo "127.0.0.1   dev.foiamachine.org" >> /etc/hosts`.  Then pointing your browser to `dev.foiamachine.org` will take you to FOIAMachine - the correst page is shown depending on the domain host.
+FOIAMachine is our free FOIA filing tool, that allows you to track your requests while requiring you to manually handle all of the message sending and receiving.  It is run off of the same code base as MuckRock.  To access it, set `dev.foiamachine.org` to point to localhost - `sudo echo "127.0.0.1   dev.foiamachine.org" >> /etc/hosts`.  Then pointing your browser to `dev.foiamachine.org` will take you to FOIAMachine - the correct page is shown depending on the domain host.
 
 ## Update search index
 

--- a/muckrock/agency/importer.py
+++ b/muckrock/agency/importer.py
@@ -75,7 +75,7 @@ class Importer:
         """Match the jurisdiction name"""
         jurisdiction_name = datum["jurisdiction"]
         # if there is a comma in the name, it is a locality state pair
-        # seperate and try to find an exact match
+        # separate and try to find an exact match
         if "," in jurisdiction_name:
             locality, state = [j.strip() for j in jurisdiction_name.split(",", 1)]
             jurisdiction = Jurisdiction.objects.filter(

--- a/muckrock/communication/models.py
+++ b/muckrock/communication/models.py
@@ -561,7 +561,7 @@ class PortalCommunication(models.Model):
 
 
 class EmailError(models.Model):
-    """An error has occured delivering this email"""
+    """An error has occurred delivering this email"""
 
     email = models.ForeignKey(
         "communication.EmailCommunication",
@@ -586,7 +586,7 @@ class EmailError(models.Model):
 
 
 class FaxError(models.Model):
-    """An error has occured delivering this fax"""
+    """An error has occurred delivering this fax"""
 
     fax = models.ForeignKey(
         "communication.FaxCommunication",

--- a/muckrock/crowdsource/forms.py
+++ b/muckrock/crowdsource/forms.py
@@ -175,7 +175,7 @@ class CrowdsourceForm(forms.ModelForm, CrowdsourceDataCsvForm):
     )
     form_json = forms.CharField(widget=forms.HiddenInput(), initial="[]")
     submission_emails = forms.CharField(
-        help_text="Comma seperated list of emails to send to on submission",
+        help_text="Comma separated list of emails to send to on submission",
         required=False,
     )
 

--- a/muckrock/crowdsource/models.py
+++ b/muckrock/crowdsource/models.py
@@ -244,7 +244,7 @@ class Crowdsource(models.Model):
         total = len(users)
 
         def join_names(users):
-            """Create a comma seperated list of user names"""
+            """Create a comma separated list of user names"""
             return ", ".join(u.profile.full_name or u.username for u in users)
 
         if total > 4:

--- a/muckrock/foia/admin.py
+++ b/muckrock/foia/admin.py
@@ -285,7 +285,7 @@ class FOIACommunicationInline(admin.StackedInline):
             return None
 
     def open(self, instance):
-        """Was this communicaion opened?"""
+        """Was this communication opened?"""
         return instance.opens_count > 0
 
     open.boolean = True
@@ -568,7 +568,7 @@ class FOIARequestAdmin(VersionAdmin):
     def autoimport(self, request):
         """Autoimport documents from S3"""
         autoimport.apply_async()
-        messages.info(request, "Auotimport started")
+        messages.info(request, "Autoimport started")
         return HttpResponseRedirect(reverse("admin:foia_foiarequest_changelist"))
 
 

--- a/muckrock/foia/models/communication.py
+++ b/muckrock/foia/models/communication.py
@@ -131,7 +131,7 @@ class FOIACommunication(models.Model):
     opened = models.BooleanField(
         default=False,
         help_text="DEPRECATED: If emailed, did we receive an open notification?"
-        " If faxed, did we recieve a confirmation?",
+        " If faxed, did we receive a confirmation?",
     )
 
     objects = FOIACommunicationQuerySet.as_manager()
@@ -493,7 +493,7 @@ class FOIACommunication(models.Model):
 
 
 class RawEmail(models.Model):
-    """The raw email text for a communication - stored seperately for performance"""
+    """The raw email text for a communication - stored separately for performance"""
 
     # nullable during transition
     # communication is depreacted and should be removed
@@ -576,7 +576,7 @@ class FOIANote(models.Model):
 
 
 class CommunicationError(models.Model):
-    """An error has occured delivering this communication"""
+    """An error has occurred delivering this communication"""
 
     # Depreacted
     communication = models.ForeignKey(

--- a/muckrock/foia/models/templates.py
+++ b/muckrock/foia/models/templates.py
@@ -125,7 +125,7 @@ class FOIATemplate(models.Model):
             ),
             make_tag(
                 "{ days }",
-                "Number of says statue requires or default of 10 days if no "
+                "Number of days statute requires or default of 10 days if no "
                 "requirement",
             ),
             make_tag(
@@ -133,7 +133,7 @@ class FOIATemplate(models.Model):
             ),
             make_tag(
                 "{ waiver }",
-                "This will be replaced by jurisdiction approriate fee waiver language "
+                "This will be replaced by jurisdiction appropriate fee waiver language "
                 "if available, or generic fee waiver language otherwise",
             ),
             ("{ requested docs }", requested_docs),

--- a/muckrock/foia/querysets.py
+++ b/muckrock/foia/querysets.py
@@ -37,7 +37,7 @@ class PreloadFileQuerysetMixin:
         self._preload_files_done = False
 
     def _clone(self):
-        """Add _preload_files_amt to vlaues to copy over in a clone"""
+        """Add _preload_files_amt to values to copy over in a clone"""
         # pylint: disable=protected-access
         clone = super()._clone()
         clone._preload_files_amt = self._preload_files_amt

--- a/muckrock/portal/exceptions.py
+++ b/muckrock/portal/exceptions.py
@@ -4,4 +4,4 @@ Exceptions used by the portal app
 
 
 class PortalError(Exception):
-    """An error occured during automatic Portal interaction"""
+    """An error occurred during automatic Portal interaction"""

--- a/muckrock/task/models.py
+++ b/muckrock/task/models.py
@@ -459,7 +459,7 @@ class ReviewAgencyTask(Task):
                 (k, list(v))
                 for k, v in groupby(open_requests, lambda f: getattr(f, email_or_fax))
             ]
-            # do seperate queries for per email addr/fax number stats
+            # do separate queries for per email addr/fax number stats
             # do annotations separately for performance reasons (limit joins)
             addresses = address_model.objects.annotate(
                 error_count=Count("errors", distinct=True),


### PR DESCRIPTION
## Summary

Fixes spelling errors found across the codebase in docstrings, comments, user-facing messages, and README documentation. All changes are typo corrections only — no behavioral changes.

### User-facing fixes
- **FOIA template tooltips** (`templates.py`): "Number of says statue requires" -> "Number of days statute requires", "jurisdiction approriate" -> "jurisdiction appropriate"
- **Admin interface** (`admin.py`): "Auotimport started" -> "Autoimport started"
- **Crowdsource form help text** (`forms.py`): "Comma seperated list" -> "Comma separated list"

### Code comments and docstrings
- `admin.py`: "communicaion" -> "communication"
- `querysets.py`: "vlaues" -> "values"
- `foia/models/communication.py`: "recieve" -> "receive", "seperately" -> "separately", "occured" -> "occurred"
- `communication/models.py`: "occured" -> "occurred" (2 instances)
- `portal/exceptions.py`: "occured" -> "occurred"
- `agency/importer.py`: "seperate" -> "separate"
- `crowdsource/models.py`: "seperated" -> "separated"
- `task/models.py`: "seperate" -> "separate"

### Documentation
- `README.md`: "unfmiliar" -> "unfamiliar", "distrubuted" -> "distributed", "comtainer" -> "container", "develpoment" -> "development", "correst" -> "correct"

## Test plan
- [ ] Verify no behavioral changes — all modifications are string-only corrections in comments, docstrings, help text, and user messages
- [ ] CI passes (no code logic affected)