### PR TITLE
Redirect to home page if object is none

### DIFF
--- a/muckrock/foia/views/communications.py
+++ b/muckrock/foia/views/communications.py
@@ -59,6 +59,9 @@ class FOIACommunicationDirectAgencyView(SingleObjectMixin, FormView):
         """Check if the communication requires a passcode"""
         self.object = self.get_object()
 
+        if not self.object or not self.object.foia:
+            return redirect("index")
+
         if self.object.foia.has_perm(request.user, "view"):
             url = furl(self.object.get_absolute_url())
             url.args["agency"] = 1


### PR DESCRIPTION
As discussed on Slack to fix this sentry error:
https://muckrock.sentry.io/issues/4102060334/events/c062ac0acb4f4f71a5d9812dd7c72707/?project=996&query=is%3Aunresolved&referrer=previous-event