### PR TITLE
Fix: sanitize surrogates in email file attachments

### DIFF
--- a/muckrock/foia/models/communication.py
+++ b/muckrock/foia/models/communication.py
@@ -390,11 +390,14 @@ class FOIACommunication(models.Model):
             content = file_.ffile.read()
             mimetype, _ = mimetypes.guess_type(name)
             if mimetype and mimetype.startswith("text/"):
-                enc = chardet.detect(content)["encoding"]
-                if enc is not None:
-                    content = sanitize_surrogates(content.decode(enc))
+                if isinstance(content, str):
+                    content = sanitize_surrogates(content)
                 else:
-                    content = content.decode("utf-8", "replace")
+                    enc = chardet.detect(content)["encoding"]
+                    if enc is not None:
+                        content = sanitize_surrogates(content.decode(enc))
+                    else:
+                        content = content.decode("utf-8", "replace")
             msg.attach(name, content)
 
     def get_raw_email(self):

--- a/muckrock/foia/models/communication.py
+++ b/muckrock/foia/models/communication.py
@@ -26,6 +26,7 @@ from muckrock.core.storage import PrivateMediaRootS3BotoStorage
 from muckrock.core.utils import UnclosableFile, new_action
 from muckrock.foia.models.file import FOIAFile
 from muckrock.foia.models.request import STATUS, FOIARequest
+from muckrock.foia.utils import sanitize_surrogates
 from muckrock.foia.querysets import FOIACommunicationQuerySet, RawEmailQuerySet
 from muckrock.task.constants import SNAIL_MAIL_CATEGORIES
 
@@ -390,7 +391,10 @@ class FOIACommunication(models.Model):
             mimetype, _ = mimetypes.guess_type(name)
             if mimetype and mimetype.startswith("text/"):
                 enc = chardet.detect(content)["encoding"]
-                content = content.decode(enc)
+                if enc is not None:
+                    content = sanitize_surrogates(content.decode(enc))
+                else:
+                    content = content.decode("utf-8", "replace")
             msg.attach(name, content)
 
     def get_raw_email(self):

--- a/muckrock/foia/tests/test_communication.py
+++ b/muckrock/foia/tests/test_communication.py
@@ -342,5 +342,5 @@ class TestAttachFilesToEmail(test.TestCase):
 
         msg.attach.assert_called_once()
         _, attached_content = msg.attach.call_args[0][:2]
-        if isinstance(attached_content, str):
-            assert attached_content == original
+        assert isinstance(attached_content, str)
+        assert attached_content == original

--- a/muckrock/foia/tests/test_communication.py
+++ b/muckrock/foia/tests/test_communication.py
@@ -8,6 +8,8 @@ from django import test
 # Standard Library
 import logging
 import os
+from io import BytesIO
+from unittest.mock import MagicMock
 
 # Third Party
 import pytest
@@ -278,3 +280,67 @@ class TestCommunicationClone(RunCommitHooksMixin, test.TestCase):
         assert not self.comm.files.all()[0].ffile
         other_foia = FOIARequestFactory()
         self.comm.clone([other_foia], self.user)
+
+
+class TestAttachFilesToEmail(test.TestCase):
+    """Test that attach_files_to_email handles encoding edge cases"""
+
+    def setUp(self):
+        self.foia = FOIARequestFactory()
+        self.comm = FOIACommunicationFactory(foia=self.foia)
+
+    def _make_text_file(self, content, filename="test.txt"):
+        """Create a FOIAFile with the given bytes content"""
+        foia_file = FOIAFileFactory(comm=self.comm)
+        foia_file.ffile.save(filename, BytesIO(content))
+        return foia_file
+
+    def test_attach_text_file_with_surrogates(self):
+        """Text files decoded by chardet should have surrogates sanitized"""
+        # Construct bytes that, when decoded as UTF-16LE, produce surrogates.
+        # Mock chardet to force this decoding path.
+        text_with_surrogate = "Hello \ud800 World"
+        raw_bytes = text_with_surrogate.encode("utf-16-le", "surrogatepass")
+        self._make_text_file(raw_bytes)
+
+        with patch(
+            "muckrock.foia.models.communication.chardet.detect",
+            return_value={"encoding": "utf-16-le", "confidence": 1.0},
+        ):
+            msg = MagicMock()
+            self.comm.attach_files_to_email(msg)
+
+        msg.attach.assert_called_once()
+        _, attached_content = msg.attach.call_args[0][:2]
+        assert isinstance(attached_content, str)
+        # Should encode cleanly without UnicodeEncodeError
+        attached_content.encode("utf-8")
+        assert "\ud800" not in attached_content
+
+    def test_attach_text_file_with_undetectable_encoding(self):
+        """Files with undetectable encoding should fall back to utf-8 replace"""
+        self._make_text_file(b"some content")
+
+        with patch(
+            "muckrock.foia.models.communication.chardet.detect",
+            return_value={"encoding": None, "confidence": 0.0},
+        ):
+            msg = MagicMock()
+            self.comm.attach_files_to_email(msg)
+
+        msg.attach.assert_called_once()
+        _, attached_content = msg.attach.call_args[0][:2]
+        assert isinstance(attached_content, str)
+
+    def test_attach_text_file_preserves_valid_content(self):
+        """Valid UTF-8 text files should pass through unchanged"""
+        original = "Hello World! Special chars: éàü"
+        self._make_text_file(original.encode("utf-8"))
+
+        msg = MagicMock()
+        self.comm.attach_files_to_email(msg)
+
+        msg.attach.assert_called_once()
+        _, attached_content = msg.attach.call_args[0][:2]
+        if isinstance(attached_content, str):
+            assert attached_content == original


### PR DESCRIPTION
## Summary

Addresses #2098. The existing surrogate sanitization (PR #2106) covers email subject and body, but `attach_files_to_email()` in `communication.py` was missed — it's a remaining vector for the same `UnicodeEncodeError` crash.

**The problem:** When a text file attachment is decoded using a chardet-detected encoding, the decoded string can contain surrogate characters (U+D800-U+DFFF). These surrogates get embedded in the MIME message and crash `msg.message().as_bytes()` at line 954 of `request.py`.

**Two bugs fixed:**
1. `content.decode(enc)` — decoded text wasn't passed through `sanitize_surrogates()`, so surrogate characters survived into the email
2. `chardet.detect()` can return `encoding: None` (e.g., for empty files or unrecognizable content), which caused `content.decode(None)` → `TypeError`

## Changes

- **`communication.py`** — added `sanitize_surrogates()` call after chardet-based decoding, with `enc is None` fallback to `utf-8` with replace error handler
- **`test_communication.py`** — 3 new tests: surrogate sanitization (mocked chardet → UTF-16LE), undetectable encoding fallback (mocked chardet → None), and valid content passthrough

## Test plan

- [ ] Existing communication tests pass
- [ ] New tests verify surrogate sanitization, None encoding handling, and valid content passthrough
- [ ] The Sentry error from #2098 should stop recurring for attachment-triggered cases