### PR TITLE
Adds an APIv1 killswitch

### DIFF
--- a/muckrock/core/urls.py
+++ b/muckrock/core/urls.py
@@ -166,7 +166,6 @@ urlpatterns = [
     re_path(r"^squarelet/", include("muckrock.squarelet.urls")),
     re_path(r"^admin/", admin.site.urls),
     re_path(r"^search/$", views.SearchView.as_view(), name="search"),
-    re_path(r"^api_v1/", include(router.urls)),
     re_path(r"^api_v2/", include(router_v2.urls)),
     re_path(r"^robots\.txt$", include("robots.urls")),
     re_path(
@@ -222,3 +221,7 @@ if settings.DEBUG:
         re_path(r"^404/$", TemplateView.as_view(template_name="404.html")),
         # re_path(r"^silk/", include("silk.urls", namespace="silk")),
     ]
+
+# If ENABLE_API_V1 is False, then this won't work.
+if settings.ENABLE_API_V1:
+    urlpatterns.append(re_path(r"^api_v1/", include(router.urls)))

--- a/muckrock/settings/base.py
+++ b/muckrock/settings/base.py
@@ -976,3 +976,6 @@ SECURE_CROSS_ORIGIN_OPENER_POLICY = os.environ.get(
 # Settings to auto-disable the GovQA automation
 GOVQA_DISABLE_TIME_LIMIT = os.environ.get("GOVQA_DISABLE_TIME_LIMIT", 5)
 GOVQA_DISABLE_AMOUNT = os.environ.get("GOVQA_DISABLE_AMOUNT", 3)
+
+# APIv1 Killswitch
+ENABLE_API_V1 = boolcheck(os.environ.get("ENABLE_API_V1", True))


### PR DESCRIPTION
As discussed in last tech team check in, this allows us to turn it off and on. You can test in the deploy preview, there is an environment variable in Heroku. It is set to False currently. You can set it back to True, wait a few minutes and verify that api_v1 is back on. 