### PR TITLE
Add authentication mixin to projects apiv2

### DIFF
--- a/muckrock/project/api_v2/viewsets.py
+++ b/muckrock/project/api_v2/viewsets.py
@@ -5,12 +5,16 @@ import django_filters
 from rest_framework import mixins, viewsets
 
 # MuckRock
+from muckrock.core.views import AuthenticatedAPIMixin
 from muckrock.project.api_v2.serializers import ProjectSerializer
 from muckrock.project.models import Project
 
 
 class ProjectViewSet(
-    mixins.RetrieveModelMixin, mixins.ListModelMixin, viewsets.GenericViewSet
+    AuthenticatedAPIMixin,
+    mixins.RetrieveModelMixin,
+    mixins.ListModelMixin,
+    viewsets.GenericViewSet,
 ):
     """
     API viewset for Projects


### PR DESCRIPTION
Projects endpoint wasn't using JWT at all, it was missing a mixin. @nielsenau Pointed this out on Slack and this should be the fix. 