### PR TITLE
Create detailed ZenDesk tickets from Get Help submissions

### DIFF
--- a/muckrock/assets/components/ContactForm.svelte
+++ b/muckrock/assets/components/ContactForm.svelte
@@ -1,7 +1,12 @@
 <script>
   import { showMessage } from "../js/messages";
 
-  let { flagCategory = "", csrfToken = "" } = $props();
+  let {
+    csrfToken = "",
+    foiaPk = "",
+    categoryLabel = "",
+    problemTitle = "",
+  } = $props();
   let text = $state("");
   let submitted = $state(false);
   let errorMessage = $state("");
@@ -15,7 +20,7 @@
     const formData = new FormData(form);
 
     try {
-      const response = await fetch(window.location.href, {
+      const response = await fetch("/gethelp/contact/", {
         method: "POST",
         headers: {
           "X-Requested-With": "XMLHttpRequest",
@@ -45,11 +50,12 @@
 
 <form method="post" class="get-help__contact-form" onsubmit={handleSubmit}>
   <input type="hidden" name="csrfmiddlewaretoken" value={csrfToken} />
-  <input type="hidden" name="action" value="flag" />
-  <input type="hidden" name="flag-category" value={flagCategory} />
+  <input type="hidden" name="foia_pk" value={foiaPk} />
+  <input type="hidden" name="category_label" value={categoryLabel} />
+  <input type="hidden" name="problem_title" value={problemTitle} />
   <textarea
-    id="flag-text"
-    name="flag-text"
+    id="text"
+    name="text"
     bind:value={text}
     required
     rows="4"

--- a/muckrock/assets/components/GetHelp.svelte
+++ b/muckrock/assets/components/GetHelp.svelte
@@ -85,12 +85,13 @@
     <ProblemList
       category={problems[selectedCategory]}
       {csrfToken}
+      foiaPk={foiaId}
       onBack={goBack}
     />
   {:else if view === "contact"}
     <div class="get-help__contact-view">
       <h3>Contact Support</h3>
-      <ContactForm flagCategory="" {csrfToken} />
+      <ContactForm {csrfToken} foiaPk={foiaId} />
     </div>
   {/if}
   </main>

--- a/muckrock/assets/components/ProblemItem.svelte
+++ b/muckrock/assets/components/ProblemItem.svelte
@@ -2,7 +2,7 @@
   import ContactForm from "./ContactForm.svelte";
   import Self from './ProblemItem.svelte';
 
-  let { problem, csrfToken = "" } = $props();
+  let { problem, csrfToken = "", foiaPk = "", categoryLabel = "" } = $props();
   let showContact = $state(false);
 </script>
 
@@ -18,9 +18,9 @@
     {#if problem.children && problem.children.length > 0}
       <div class="get-help__children">
         {#each problem.children as child (child.id)}
-          <Self problem={child} {csrfToken} />
+          <Self problem={child} {csrfToken} {foiaPk} {categoryLabel} />
         {/each}
-        <Self problem={{id: "other", title: "Other"}} {csrfToken} />
+        <Self problem={{id: "other", title: "Other"}} {csrfToken} {foiaPk} {categoryLabel} />
       </div>
     {:else}
       {#if problem.resolution_html && !showContact}
@@ -32,7 +32,7 @@
           I still need help
       </button>
       {:else}
-      <ContactForm flagCategory={problem.flag_category} {csrfToken} />
+      <ContactForm {csrfToken} {foiaPk} {categoryLabel} problemTitle={problem.title} />
       {/if}
     {/if}
   </div>

--- a/muckrock/assets/components/ProblemList.svelte
+++ b/muckrock/assets/components/ProblemList.svelte
@@ -1,7 +1,7 @@
 <script>
   import ProblemItem from "./ProblemItem.svelte";
 
-  let { category, csrfToken = "" } = $props();
+  let { category, csrfToken = "", foiaPk = "" } = $props();
 
   let otherProblem = {
     title: "I need help with something else.",
@@ -12,10 +12,10 @@
   <h3>{category.label}</h3>
 
   {#each category.problems as problem (problem.id)}
-    <ProblemItem {problem} {csrfToken} />
+    <ProblemItem {problem} {csrfToken} {foiaPk} categoryLabel={category.label} />
   {/each}
 
-  <ProblemItem problem={otherProblem} {csrfToken} />
+  <ProblemItem problem={otherProblem} {csrfToken} {foiaPk} categoryLabel={category.label} />
 </div>
 
 <style>

--- a/muckrock/core/urls.py
+++ b/muckrock/core/urls.py
@@ -163,6 +163,7 @@ urlpatterns = [
     re_path(r"^project/", include("muckrock.project.urls")),
     re_path(r"^fine-uploader/", include("muckrock.fine_uploader.urls")),
     re_path(r"^communication/", include("muckrock.communication.urls")),
+    re_path(r"^gethelp/", include("muckrock.gethelp.urls")),
     re_path(r"^squarelet/", include("muckrock.squarelet.urls")),
     re_path(r"^admin/", admin.site.urls),
     re_path(r"^search/$", views.SearchView.as_view(), name="search"),

--- a/muckrock/core/utils.py
+++ b/muckrock/core/utils.py
@@ -25,6 +25,14 @@ import actstream
 import boto3
 import requests
 import stripe
+from zenpy import Zenpy
+from zenpy.lib.api_objects import (
+    Comment,
+    Organization as ZenOrg,
+    Ticket,
+    User as ZenUser,
+)
+from zenpy.lib.exception import APIException
 
 logger = logging.getLogger(__name__)
 
@@ -262,6 +270,65 @@ def zoho_get(path, params=None):
     if params is None:
         params = {}
     return _zoho(requests.get, path, params=params)
+
+
+def get_zendesk_client():
+    """Return a configured Zenpy client."""
+    return Zenpy(
+        email=settings.ZENDESK_EMAIL,
+        subdomain=settings.ZENDESK_SUBDOMAIN,
+        token=settings.ZENDESK_TOKEN,
+    )
+
+
+def create_zendesk_ticket(
+    subject, description, tags, requester_data, org_data=None, custom_fields=None
+):
+    """Create a Zendesk ticket and return its integer ticket ID.
+
+    requester_data: dict with at least `name`; optionally `email`, `external_id`
+    org_data:       dict with `name` + `external_id`, or None
+    custom_fields:  list of {id, value} dicts, or None
+    """
+    client = get_zendesk_client()
+
+    org_id = None
+    if org_data:
+        try:
+            org = client.organizations.create_or_update(ZenOrg(**org_data))
+        except APIException:
+            # De-duplicate name
+            deduped = dict(org_data) # Create new dict from org_data
+            deduped["name"] += "_" + deduped["external_id"][:6]
+            org = client.organizations.create_or_update(ZenOrg(**deduped))
+        org_id = org.id
+    if org_id:
+        requester_data = dict(requester_data, organization_id=org_id)
+    
+    try:
+        user = client.users.create_or_update(ZenUser(**requester_data))
+    except APIException:
+        # merge conflicting users
+        user1 = list(client.users.search(external_id=requester_data["external_id"]))[0]
+        user2 = list(client.users.search(query=requester_data["email"]))[0]
+        user = client.users.merge(user1, user2)
+
+    ticket_kwargs = {
+        "subject": subject,
+        "comment": Comment(body=description),
+        "type": "task",
+        "priority": "normal",
+        "status": "new",
+        "tags": list(tags or []),
+        "requester_id": user.id,
+    }
+    if org_id:
+        ticket_kwargs["organization_id"] = org_id
+    if custom_fields:
+        ticket_kwargs["custom_fields"] = custom_fields
+
+    audit = client.tickets.create(Ticket(**ticket_kwargs))
+    return audit.ticket.id
 
 
 def get_s3_storage_bucket():

--- a/muckrock/core/utils.py
+++ b/muckrock/core/utils.py
@@ -298,13 +298,13 @@ def create_zendesk_ticket(
             org = client.organizations.create_or_update(ZenOrg(**org_data))
         except APIException:
             # De-duplicate name
-            deduped = dict(org_data) # Create new dict from org_data
+            deduped = dict(org_data)  # Create new dict from org_data
             deduped["name"] += "_" + deduped["external_id"][:6]
             org = client.organizations.create_or_update(ZenOrg(**deduped))
         org_id = org.id
     if org_id:
         requester_data = dict(requester_data, organization_id=org_id)
-    
+
     try:
         user = client.users.create_or_update(ZenUser(**requester_data))
     except APIException:

--- a/muckrock/gethelp/forms.py
+++ b/muckrock/gethelp/forms.py
@@ -1,0 +1,14 @@
+"""Forms for the gethelp app"""
+
+# Django
+from django import forms
+
+
+class GetHelpForm(forms.Form):
+    text = forms.CharField(
+        strip=True,
+        error_messages={"required": "Please describe your issue."},
+    )
+    foia_pk = forms.IntegerField(required=False)
+    category_label = forms.CharField(required=False)
+    problem_title = forms.CharField(required=False)

--- a/muckrock/gethelp/tasks.py
+++ b/muckrock/gethelp/tasks.py
@@ -18,6 +18,7 @@ from zenpy.lib.exception import APIException, ZenpyException
 # MuckRock
 from muckrock.core.utils import create_zendesk_ticket
 from muckrock.foia.models import FOIARequest
+from muckrock.organization.models import Membership
 
 logger = logging.getLogger(__name__)
 
@@ -69,8 +70,17 @@ def create_ticket_data(user, foia):
         if foia:
             primary_org = foia.composer.organization
         else:
-            primary_org = user.profile.organization
-        org_data = {"name": primary_org.name, "external_id": str(primary_org.uuid)}
+            try:
+                primary_org = user.profile.organization
+            except Membership.DoesNotExist:
+                primary_org = None
+        if primary_org:
+            org_data = {
+                "name": primary_org.name,
+                "external_id": str(primary_org.uuid),
+            }
+        else:
+            org_data = None
     else:
         requester_data = {"name": "Anonymous User"}
         org_data = None
@@ -83,7 +93,7 @@ def create_gethelp_ticket(
 ):
     """Create a Zendesk support ticket from a GetHelp form submission."""
     user = (
-        User.objects.filter(pk=user_pk).select_related("profile__organization").first()
+        User.objects.filter(pk=user_pk).select_related("profile").first()
         if user_pk
         else None
     )

--- a/muckrock/gethelp/tasks.py
+++ b/muckrock/gethelp/tasks.py
@@ -1,19 +1,21 @@
 """Celery tasks for the gethelp app"""
 
+# Django
+from celery import shared_task
+from django.conf import settings
+from django.contrib.auth.models import User
+from django.utils import timezone
+
 # Standard Library
 import logging
 import sys
 from random import randint
 
 # Third Party
-from celery import shared_task
 from requests.exceptions import RequestException
-
-from django.conf import settings
-from django.contrib.auth.models import User
-from django.utils import timezone
 from zenpy.lib.exception import APIException, ZenpyException
 
+# MuckRock
 from muckrock.core.utils import create_zendesk_ticket
 from muckrock.foia.models import FOIARequest
 
@@ -22,19 +24,7 @@ logger = logging.getLogger(__name__)
 MR_NUMBER_FIELD = 1500004565182
 
 
-@shared_task(ignore_result=True, max_retries=5)
-def create_gethelp_ticket(
-    user_pk, text, foia_pk=None, category_label="", problem_title=""
-):
-    """Create a Zendesk support ticket from a GetHelp form submission."""
-    user = (
-        User.objects.filter(pk=user_pk).select_related("profile__organization").first()
-        if user_pk
-        else None
-    )
-    foia = FOIARequest.objects.filter(pk=foia_pk).first() if foia_pk else None
-
-    # --- subject ---
+def create_ticket_subject(user, category_label, problem_title):
     username = user.username if user else "anonymous"
     if category_label and problem_title:
         subject = f"[{category_label}] {problem_title} @{username}"
@@ -42,8 +32,10 @@ def create_gethelp_ticket(
         subject = f"[{category_label}] @{username}"
     else:
         subject = f"[GetHelp] @{username}"
+    return subject
 
-    # --- description ---
+
+def create_ticket_description(text, user, foia):
     description = text
     if foia:
         description += f"\n\nRequest: {settings.MUCKROCK_URL}{foia.get_absolute_url()}"
@@ -53,14 +45,20 @@ def create_gethelp_ticket(
         )
         for org in user.organizations.filter(individual=False):
             plan = "Premium" if org.entitlement.base_requests > 0 else "Free"
-            description += f"\nOrg: {settings.MUCKROCK_URL}{org.get_absolute_url()} ({plan})"
+            description += (
+                f"\nOrg: {settings.MUCKROCK_URL}{org.get_absolute_url()} ({plan})"
+            )
+    return description
 
-    # --- tags ---
+
+def create_ticket_tags(category_label):
     tags = ["gethelp"]
     if category_label:
         tags.append(category_label.lower().replace(" ", "_"))
+    return tags
 
-    # --- requester / org ---
+
+def create_ticket_data(user, foia):
     if user:
         requester_data = {
             "name": user.profile.full_name or user.username,
@@ -76,14 +74,28 @@ def create_gethelp_ticket(
     else:
         requester_data = {"name": "Anonymous User"}
         org_data = None
+    return [requester_data, org_data]
 
+
+@shared_task(ignore_result=True, max_retries=5)
+def create_gethelp_ticket(
+    user_pk, text, foia_pk=None, category_label="", problem_title=""
+):
+    """Create a Zendesk support ticket from a GetHelp form submission."""
+    user = (
+        User.objects.filter(pk=user_pk).select_related("profile__organization").first()
+        if user_pk
+        else None
+    )
+    foia = FOIARequest.objects.filter(pk=foia_pk).first() if foia_pk else None
+    [requester_data, org_data] = create_ticket_data(user, foia)
     custom_fields = [{"id": MR_NUMBER_FIELD, "value": foia.pk}] if foia else None
 
     try:
         ticket_id = create_zendesk_ticket(
-            subject=subject,
-            description=description,
-            tags=tags,
+            subject=create_ticket_subject(user, category_label, problem_title),
+            description=create_ticket_description(text, user, foia),
+            tags=create_ticket_tags(category_label),
             requester_data=requester_data,
             org_data=org_data,
             custom_fields=custom_fields,
@@ -92,8 +104,7 @@ def create_gethelp_ticket(
             foia.notes.create(
                 author=user,
                 datetime=timezone.now(),
-                note=f"Submitted help request:\n\n{text}\n\n"
-                f"Ticket ID: {ticket_id}",
+                note=f"Submitted help request:\n\n{text}\n\n" f"Ticket ID: {ticket_id}",
             )
     except (RequestException, ZenpyException, APIException) as exc:
         logger.warning(

--- a/muckrock/gethelp/tasks.py
+++ b/muckrock/gethelp/tasks.py
@@ -36,20 +36,46 @@ def create_ticket_subject(user, category_label, problem_title):
     return subject
 
 
-def create_ticket_description(text, user, foia):
-    description = text
+def get_primary_org(user, foia):
+    """Return the org this ticket is associated with, or None."""
     if foia:
-        description += f"\n\nRequest: {settings.MUCKROCK_URL}{foia.get_absolute_url()}"
-    if user:
-        description += (
-            f"\nUser profile: {settings.MUCKROCK_URL}{user.profile.get_absolute_url()}"
+        return foia.composer.organization
+    try:
+        return user.profile.organization
+    except Membership.DoesNotExist:
+        return None
+
+
+def create_ticket_description(text, user, foia):
+    links = ["=== Quick Links ==="]
+    if foia:
+        links.append(
+            f"- Request on MuckRock Requests: "
+            f"{settings.MUCKROCK_URL}{foia.get_absolute_url()}"
         )
-        for org in user.organizations.filter(individual=False):
+    if user:
+        links.append(
+            f"- User profile on MuckRock Requests: "
+            f"{settings.MUCKROCK_URL}{user.profile.get_absolute_url()}"
+        )
+        links.append(
+            f"- User profile on MuckRock Accounts: "
+            f"{settings.SQUARELET_URL}/users/{user.username}/"
+        )
+        org = get_primary_org(user, foia)
+        if org and not org.individual:
             plan = "Premium" if org.entitlement.base_requests > 0 else "Free"
-            description += (
-                f"\nOrg: {settings.MUCKROCK_URL}{org.get_absolute_url()} ({plan})"
+            links.append(
+                f"- {plan} Organization on MuckRock Requests: "
+                f"{settings.MUCKROCK_URL}{org.get_absolute_url()}"
             )
-    return description
+            links.append(
+                f"- {plan} Organization on MuckRock Accounts: "
+                f"{settings.SQUARELET_URL}/organizations/{org.slug}/ "
+            )
+    if links:
+        return text + "\n\n" + "\n".join(links)
+    return text
 
 
 def create_ticket_tags(category_label):
@@ -67,13 +93,7 @@ def create_ticket_data(user, foia):
         }
         if user.email:
             requester_data["email"] = user.email
-        if foia:
-            primary_org = foia.composer.organization
-        else:
-            try:
-                primary_org = user.profile.organization
-            except Membership.DoesNotExist:
-                primary_org = None
+        primary_org = get_primary_org(user, foia)
         if primary_org:
             org_data = {
                 "name": primary_org.name,

--- a/muckrock/gethelp/tasks.py
+++ b/muckrock/gethelp/tasks.py
@@ -1,0 +1,106 @@
+"""Celery tasks for the gethelp app"""
+
+# Standard Library
+import logging
+import sys
+from random import randint
+
+# Third Party
+from celery import shared_task
+from requests.exceptions import RequestException
+
+from django.conf import settings
+from django.contrib.auth.models import User
+from django.utils import timezone
+from zenpy.lib.exception import APIException, ZenpyException
+
+from muckrock.core.utils import create_zendesk_ticket
+from muckrock.foia.models import FOIARequest
+
+logger = logging.getLogger(__name__)
+
+MR_NUMBER_FIELD = 1500004565182
+
+
+@shared_task(ignore_result=True, max_retries=5)
+def create_gethelp_ticket(
+    user_pk, text, foia_pk=None, category_label="", problem_title=""
+):
+    """Create a Zendesk support ticket from a GetHelp form submission."""
+    user = (
+        User.objects.filter(pk=user_pk).select_related("profile__organization").first()
+        if user_pk
+        else None
+    )
+    foia = FOIARequest.objects.filter(pk=foia_pk).first() if foia_pk else None
+
+    # --- subject ---
+    username = user.username if user else "anonymous"
+    if category_label and problem_title:
+        subject = f"[{category_label}] {problem_title} @{username}"
+    elif category_label:
+        subject = f"[{category_label}] @{username}"
+    else:
+        subject = f"[GetHelp] @{username}"
+
+    # --- description ---
+    description = text
+    if foia:
+        description += f"\n\nRequest: {settings.MUCKROCK_URL}{foia.get_absolute_url()}"
+    if user:
+        description += (
+            f"\nUser profile: {settings.MUCKROCK_URL}{user.profile.get_absolute_url()}"
+        )
+        for org in user.organizations.filter(individual=False):
+            plan = "Premium" if org.entitlement.base_requests > 0 else "Free"
+            description += f"\nOrg: {settings.MUCKROCK_URL}{org.get_absolute_url()} ({plan})"
+
+    # --- tags ---
+    tags = ["gethelp"]
+    if category_label:
+        tags.append(category_label.lower().replace(" ", "_"))
+
+    # --- requester / org ---
+    if user:
+        requester_data = {
+            "name": user.profile.full_name or user.username,
+            "external_id": str(user.profile.uuid),
+        }
+        if user.email:
+            requester_data["email"] = user.email
+        if foia:
+            primary_org = foia.composer.organization
+        else:
+            primary_org = user.profile.organization
+        org_data = {"name": primary_org.name, "external_id": str(primary_org.uuid)}
+    else:
+        requester_data = {"name": "Anonymous User"}
+        org_data = None
+
+    custom_fields = [{"id": MR_NUMBER_FIELD, "value": foia.pk}] if foia else None
+
+    try:
+        ticket_id = create_zendesk_ticket(
+            subject=subject,
+            description=description,
+            tags=tags,
+            requester_data=requester_data,
+            org_data=org_data,
+            custom_fields=custom_fields,
+        )
+        if foia and user and foia.has_perm(user, "change"):
+            foia.notes.create(
+                author=user,
+                datetime=timezone.now(),
+                note=f"Submitted help request:\n\n{text}\n\n"
+                f"Ticket ID: {ticket_id}",
+            )
+    except (RequestException, ZenpyException, APIException) as exc:
+        logger.warning(
+            "Zendesk error in create_gethelp_ticket: %s", exc, exc_info=sys.exc_info()
+        )
+        raise create_gethelp_ticket.retry(
+            countdown=(2**create_gethelp_ticket.request.retries) * 300
+            + randint(0, 300),
+            exc=exc,
+        )

--- a/muckrock/gethelp/urls.py
+++ b/muckrock/gethelp/urls.py
@@ -1,0 +1,11 @@
+"""URL configuration for the gethelp app"""
+
+# Django
+from django.urls import path
+
+# MuckRock
+from muckrock.gethelp import views
+
+urlpatterns = [
+    path("contact/", views.contact, name="gethelp-contact"),
+]

--- a/muckrock/gethelp/views.py
+++ b/muckrock/gethelp/views.py
@@ -1,0 +1,35 @@
+"""Views for the gethelp app"""
+
+# Django
+from django.conf import settings
+from django.http import JsonResponse
+from django.views.decorators.http import require_POST
+
+# MuckRock
+from muckrock.gethelp.tasks import create_gethelp_ticket
+
+
+@require_POST
+def contact(request):
+    """Queue a Zendesk support ticket from the Get Help form."""
+    text = request.POST.get("text", "").strip()
+    if not text:
+        return JsonResponse({"message": "Please describe your issue."}, status=400)
+
+    user_pk = request.user.pk if request.user.is_authenticated else None
+    foia_pk = request.POST.get("foia_pk") or None
+    category_label = request.POST.get("category_label", "")
+    problem_title = request.POST.get("problem_title", "")
+
+    if settings.USE_ZENDESK:
+        create_gethelp_ticket.delay(
+            user_pk=user_pk,
+            text=text,
+            foia_pk=foia_pk,
+            category_label=category_label,
+            problem_title=problem_title,
+        )
+
+    return JsonResponse(
+        {"message": "Your message has been sent. We'll be in touch soon."}
+    )

--- a/muckrock/gethelp/views.py
+++ b/muckrock/gethelp/views.py
@@ -6,28 +6,27 @@ from django.http import JsonResponse
 from django.views.decorators.http import require_POST
 
 # MuckRock
+from muckrock.gethelp.forms import GetHelpForm
 from muckrock.gethelp.tasks import create_gethelp_ticket
 
 
 @require_POST
 def contact(request):
     """Queue a Zendesk support ticket from the Get Help form."""
-    text = request.POST.get("text", "").strip()
-    if not text:
-        return JsonResponse({"message": "Please describe your issue."}, status=400)
+    form = GetHelpForm(request.POST)
+    if not form.is_valid():
+        first_error = next(iter(form.errors.values()))[0]
+        return JsonResponse({"message": first_error}, status=400)
 
     user_pk = request.user.pk if request.user.is_authenticated else None
-    foia_pk = request.POST.get("foia_pk") or None
-    category_label = request.POST.get("category_label", "")
-    problem_title = request.POST.get("problem_title", "")
 
     if settings.USE_ZENDESK:
         create_gethelp_ticket.delay(
             user_pk=user_pk,
-            text=text,
-            foia_pk=foia_pk,
-            category_label=category_label,
-            problem_title=problem_title,
+            text=form.cleaned_data["text"],
+            foia_pk=form.cleaned_data["foia_pk"],
+            category_label=form.cleaned_data["category_label"],
+            problem_title=form.cleaned_data["problem_title"],
         )
 
     return JsonResponse(

--- a/muckrock/task/models.py
+++ b/muckrock/task/models.py
@@ -27,7 +27,7 @@ from taggit.managers import TaggableManager
 from muckrock.communication.models import Check, EmailAddress, PhoneNumber
 from muckrock.core.forms import TagManagerForm
 from muckrock.core.models import ExtractDay
-from muckrock.core.utils import zoho_get, zoho_post, create_zendesk_ticket
+from muckrock.core.utils import create_zendesk_ticket, zoho_get, zoho_post
 from muckrock.foia.models import STATUS, FOIATemplate
 from muckrock.jurisdiction.models import Jurisdiction
 from muckrock.message.email import TemplateEmail

--- a/muckrock/task/models.py
+++ b/muckrock/task/models.py
@@ -22,20 +22,12 @@ from itertools import groupby
 # Third Party
 import bleach
 from taggit.managers import TaggableManager
-from zenpy import Zenpy
-from zenpy.lib.api_objects import (
-    Comment,
-    Organization as ZenOrganization,
-    Ticket,
-    User as ZenUser,
-)
-from zenpy.lib.exception import APIException
 
 # MuckRock
 from muckrock.communication.models import Check, EmailAddress, PhoneNumber
 from muckrock.core.forms import TagManagerForm
 from muckrock.core.models import ExtractDay
-from muckrock.core.utils import zoho_get, zoho_post
+from muckrock.core.utils import zoho_get, zoho_post, create_zendesk_ticket
 from muckrock.foia.models import STATUS, FOIATemplate
 from muckrock.jurisdiction.models import Jurisdiction
 from muckrock.message.email import TemplateEmail
@@ -127,37 +119,19 @@ class Task(models.Model):
         return user.is_staff
 
     def create_zendesk_ticket(self, note, email):
-        client = Zenpy(
-            email=settings.ZENDESK_EMAIL,
-            subdomain=settings.ZENDESK_SUBDOMAIN,
-            token=settings.ZENDESK_TOKEN,
-        )
-
         description = (
             f"Ticket link: {settings.MUCKROCK_URL}{self.get_absolute_url()}\n\n"
             f"Ticket created by: {email}\n\n"
             f"Note: {note}\n\n"
             f"{self.get_ticket_info()}"
         )
-
-        ticket_data = {
-            "subject": self.__class__.__name__,
-            "comment": Comment(body=description),
-            "type": "task",
-            "priority": "normal",
-            "status": "new",
-            "tags": ["tasks"],
-        }
-
-        user_data = {"name": "MuckRock Task"}
-        user = client.users.create_or_update(ZenUser(**user_data))
-
-        ticket_data["requester_id"] = user.id
-        ticket_audit = client.tickets.create(Ticket(**ticket_data))
-
-        self.zendesk_ticket_id = ticket_audit.ticket.id
+        self.zendesk_ticket_id = create_zendesk_ticket(
+            subject=self.__class__.__name__,
+            description=description,
+            tags=["tasks"],
+            requester_data={"name": "MuckRock Task"},
+        )
         self.save()
-
         return self.zendesk_ticket_id
 
     def get_ticket_info(self):
@@ -794,31 +768,19 @@ class FlaggedTask(Task):
             return None
 
     def create_zendesk_flag_ticket(self):
-        # pylint: disable=too-many-branches, too-many-locals
-        client = Zenpy(
-            email=settings.ZENDESK_EMAIL,
-            subdomain=settings.ZENDESK_SUBDOMAIN,
-            token=settings.ZENDESK_TOKEN,
-        )
-
         description = self.text
         tag = self.category.replace(" ", "_")
         # automatically extend no response tags with the acknowledgment
         # status of the foia request
         if tag == "no_response" and self.foia:
-            if self.foia.has_ack():
-                tag += "_ack"
-            else:
-                tag += "_no_ack"
+            tag += "_ack" if self.foia.has_ack() else "_no_ack"
         tags = ["flag", tag]
 
         for obj_name in ["foia", "agency", "jurisdiction"]:
             obj = getattr(self, obj_name)
             if obj:
-                description += "\n{}{}".format(
-                    settings.MUCKROCK_URL, obj.get_absolute_url()
-                )
-                tags.append("{}_flag".format(obj_name))
+                description += f"\n{settings.MUCKROCK_URL}{obj.get_absolute_url()}"
+                tags.append(f"{obj_name}_flag")
 
         if self.foia:
             description += (
@@ -835,62 +797,42 @@ class FlaggedTask(Task):
             if "free" in entitlements and len(entitlements) > 1:
                 entitlements.remove("free")
             tags.extend(entitlements)
-
-        ticket_data = {
-            "subject": self.get_category_display() or "Generic Flag",
-            "comment": Comment(body=description),
-            "type": "task",
-            "priority": "normal",
-            "status": "new",
-            "tags": tags,
-        }
-        if self.foia:
-            ticket_data["custom_fields"] = [
-                {"id": MR_NUMBER_FIELD, "value": self.foia.pk}
-            ]
-        if self.user:
-            user_data = {
+            requester_data = {
                 "name": self.user.profile.full_name or self.user.username,
                 "external_id": str(self.user.profile.uuid),
             }
             if self.user.email:
-                user_data["email"] = self.user.email
+                requester_data["email"] = self.user.email
             org_data = {
                 "name": self.user.profile.organization.name,
                 "external_id": str(self.user.profile.organization.uuid),
             }
         else:
-            user_data = {"name": "Anonymous User"}
-            org_data = {}
+            requester_data = {"name": "Anonymous User"}
+            org_data = None
 
-        if org_data:
-            try:
-                org = client.organizations.create_or_update(ZenOrganization(**org_data))
-            except APIException:
-                # De-duplicate name
-                org_data["name"] += "_" + org_data["external_id"][:6]
-                org = client.organizations.create_or_update(ZenOrganization(**org_data))
-            user_data["organization_id"] = org.id
-            ticket_data["organization_id"] = org.id
-        try:
-            user = client.users.create_or_update(ZenUser(**user_data))
-        except APIException:
-            # merge conflicting users
-            user1 = list(client.users.search(external_id=user_data["external_id"]))[0]
-            user2 = list(client.users.search(query=user_data["email"]))[0]
-            user = client.users.merge(user1, user2)
-        ticket_data["requester_id"] = user.id
-        ticket_audit = client.tickets.create(Ticket(**ticket_data))
+        custom_fields = (
+            [{"id": MR_NUMBER_FIELD, "value": self.foia.pk}] if self.foia else None
+        )
+
+        ticket_id = create_zendesk_ticket(
+            subject=self.get_category_display() or "Generic Flag",
+            description=description,
+            tags=tags,
+            requester_data=requester_data,
+            org_data=org_data,
+            custom_fields=custom_fields,
+        )
 
         if self.foia and self.user and self.foia.has_perm(self.user, "change"):
             self.foia.notes.create(
                 author=self.user,
                 datetime=timezone.now(),
                 note=f"Submitted help request:\n\n{self.text}\n\n"
-                f"https://muckrock.zendesk.com/agent/tickets/{ticket_audit.ticket.id}",
+                f"https://muckrock.zendesk.com/agent/tickets/{ticket_id}",
             )
 
-        return ticket_audit.ticket.id
+        return ticket_id
 
     def check_permission(self, user):
         """Check if a user has permission to manage this task"""


### PR DESCRIPTION
Closes #2158 

- Adds more detail to tickets generated from Get Help:
    - new subject line format: `[Category] Problem @username`
    - links to user and organization on MuckRock Requests
- Bypasses `FlaggedTask` when submitting GetHelp forms
- Cleans and validates GetHelp submission using a `GetHelpForm` class
- Refactors ZenDesk logic out from `Task` and `FlaggedTask`, into `core/utils.py`

## Testing steps

1. In the preview deployment, update the env vars so that `USE_ZENDESK` is true and use ZenDesk credentials from production.
2. In the preview deployment, submit a Get Help form on a request.
3. Check in ZenDesk that the ticket was created correctly (will need to collaborate with @adriensalz on this).