### PR TITLE
Adds 'PaymentInfoTask.get_absolute_url'

### DIFF
--- a/muckrock/task/models.py
+++ b/muckrock/task/models.py
@@ -250,6 +250,9 @@ class PaymentInfoTask(Task):
     def __str__(self):
         return "Payment Info Task"
 
+    def get_absolute_url(self):
+        return reverse("payment-info-task", kwargs={"pk": self.pk})
+
     def check_permission(self, user):
         """Check if a user has permission to manage this task"""
         return self.foia.has_perm(user, "tasks")

--- a/muckrock/task/tests/test_models.py
+++ b/muckrock/task/tests/test_models.py
@@ -36,6 +36,7 @@ from muckrock.task.models import (
     MultiRequestTask,
     NewAgencyTask,
     OrphanTask,
+    PaymentInfoTask,
     ResponseTask,
     SnailMailTask,
     StatusChangeTask,
@@ -335,6 +336,22 @@ class SnailMailTaskTests(TestCase):
         pdf = SnailMailPDF(comm, "n", switch=False)
         pdf.generate()
         pdf.output(dest="S").encode("latin-1")
+
+
+class PaymentInfoTaskTests(TestCase):
+    """Test the PaymentInfoTask class"""
+
+    def setUp(self):
+        self.user = UserFactory()
+        self.foia = FOIARequestFactory()
+        self.task = PaymentInfoTask.objects.create(
+            user=self.user, foia=self.foia, amount=100.00
+        )
+
+    def test_get_absolute_url(self):
+        assert self.task.get_absolute_url() == reverse(
+            "payment-info-task", kwargs={"pk": self.task.pk}
+        )
 
 
 class NewAgencyTaskTests(TestCase):


### PR DESCRIPTION
Fixes #2175

`PaymentInfoTask` was missing a `get_absolute_url()` method, which the base `Task.create_zendesk_ticket()` calls. Every other task class that supports Zendesk ticket creation defines this method, but PaymentInfoTask never did.