### PR TITLE
Improve printed request pages

### DIFF
--- a/muckrock/assets/print.js
+++ b/muckrock/assets/print.js
@@ -1,0 +1,2 @@
+import "vite/modulepreload-polyfill";
+import "./scss/print.scss";

--- a/muckrock/assets/scss/print.scss
+++ b/muckrock/assets/scss/print.scss
@@ -1,0 +1,184 @@
+// Print stylesheet for FOIA request detail pages.
+// Intentionally standalone — does not import the main app styles.
+
+@page {
+  margin: 0.75in;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  padding: 0;
+  background: #fff;
+  color: #111;
+  font-family: "Source Sans Pro", "Helvetica Neue", Arial, sans-serif;
+  font-size: 11pt;
+  line-height: 1.5;
+}
+
+body.print {
+  padding: 1rem;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+h1,
+h2,
+h3 {
+  font-weight: 600;
+  line-height: 1.25;
+  margin: 0 0 0.5rem;
+}
+
+p {
+  margin: 0 0 0.5rem;
+}
+
+time {
+  font-variant-numeric: tabular-nums;
+}
+
+.request-print {
+  max-width: 7in;
+  margin: 0 auto;
+}
+
+.request-print__header {
+  border-bottom: 2pt solid #111;
+  padding-bottom: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+.request-print__brand {
+  font-size: 9pt;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: #555;
+  margin: 0 0 0.5rem;
+}
+
+.request-print__title {
+  font-size: 20pt;
+  margin: 0 0 0.5rem;
+}
+
+.request-print__subtitle {
+  font-size: 12pt;
+  color: #333;
+  margin: 0 0 1rem;
+}
+
+.request-print__meta {
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  gap: 0.15rem 1rem;
+  margin: 0;
+  font-size: 10pt;
+
+  dt {
+    font-weight: 600;
+    color: #555;
+  }
+
+  dd {
+    margin: 0;
+    color: #111;
+  }
+}
+
+.request-print__section-heading {
+  font-size: 14pt;
+  border-bottom: 1pt solid #999;
+  padding-bottom: 0.25rem;
+  margin: 1.5rem 0 1rem;
+}
+
+.request-print__communication {
+  break-inside: avoid;
+  page-break-inside: avoid;
+  border: 1pt solid #ccc;
+  border-radius: 2pt;
+  padding: 0.75rem 1rem;
+  margin: 0 0 1rem;
+
+  &.is-outgoing {
+    border-left: 4pt solid #367af0;
+  }
+
+  &.is-response {
+    border-left: 4pt solid #555;
+  }
+}
+
+.request-print__communication-header {
+  border-bottom: 1pt dotted #ccc;
+  padding-bottom: 0.5rem;
+  margin-bottom: 0.5rem;
+  font-size: 10pt;
+
+  p {
+    margin: 0 0 0.15rem;
+  }
+}
+
+.request-print__label {
+  font-weight: 600;
+  color: #555;
+  display: inline-block;
+  min-width: 3.5rem;
+}
+
+.request-print__communication-body {
+  font-size: 11pt;
+  word-wrap: break-word;
+
+  // Tame any rich HTML carried over from emails.
+  img {
+    max-width: 100%;
+    height: auto;
+  }
+
+  blockquote {
+    border-left: 2pt solid #ccc;
+    margin: 0.5rem 0;
+    padding-left: 0.75rem;
+    color: #333;
+  }
+}
+
+.request-print__footer {
+  margin-top: 2rem;
+  padding-top: 0.75rem;
+  border-top: 1pt solid #ccc;
+  font-size: 9pt;
+  color: #555;
+}
+
+// Print-specific tweaks.
+@media print {
+  body.print {
+    padding: 0;
+  }
+
+  .request-print {
+    max-width: 100%;
+  }
+
+  a {
+    color: inherit;
+  }
+
+  // Show URLs after links for context.
+  a[href^="http"]::after {
+    content: " (" attr(href) ")";
+    font-size: 0.85em;
+    color: #555;
+  }
+}

--- a/muckrock/assets/scss/print.scss
+++ b/muckrock/assets/scss/print.scss
@@ -93,13 +93,6 @@ time {
   }
 }
 
-.request-print__section-heading {
-  font-size: 14pt;
-  border-bottom: 1pt solid #999;
-  padding-bottom: 0.25rem;
-  margin: 1.5rem 0 1rem;
-}
-
 .request-print__communication {
   break-inside: avoid;
   page-break-inside: avoid;

--- a/muckrock/foia/tests/test_views.py
+++ b/muckrock/foia/tests/test_views.py
@@ -142,6 +142,25 @@ class TestFOIAViews(TestCase):
             ),
         )
 
+    def test_foia_detail_print(self):
+        """The print view should render with metadata and communications"""
+
+        foia = FOIARequestFactory()
+        FOIACommunicationFactory(foia=foia)
+        response = get_allowed(
+            self.client,
+            reverse(
+                "foia-detail-print",
+                kwargs={
+                    "idx": foia.pk,
+                    "slug": foia.slug,
+                    "jurisdiction": foia.jurisdiction.slug,
+                    "jidx": foia.jurisdiction.pk,
+                },
+            ),
+        )
+        assert b"request-print" in response.content
+
     def test_feeds(self):
         """Test the RSS feed views"""
 

--- a/muckrock/foia/urls.py
+++ b/muckrock/foia/urls.py
@@ -74,6 +74,11 @@ urlpatterns = [
         name="foia-composer-detail",
     ),
     re_path(
+        r"^%s/print/$" % foia_url,
+        views.DetailPrint.as_view(),
+        name="foia-detail-print",
+    ),
+    re_path(
         r"^%s/crowdfund/$" % foia_url, views.crowdfund_request, name="foia-crowdfund"
     ),
     re_path(

--- a/muckrock/foia/views/detail.py
+++ b/muckrock/foia/views/detail.py
@@ -405,6 +405,41 @@ class Detail(DetailView):
         return redirect(self.foia.get_absolute_url() + "#")
 
 
+class DetailPrint(DetailView):
+    """A print-friendly view of a FOIA request and its communications"""
+
+    model = FOIARequest
+    context_object_name = "foia"
+    template_name = "foia/detail_print.html"
+
+    def get_object(self, queryset=None):
+        foia = get_object_or_404(
+            FOIARequest.objects.select_related(
+                "agency__jurisdiction__parent",
+                "composer__user__profile",
+            ).prefetch_related(
+                "tracking_ids",
+                Prefetch(
+                    "communications",
+                    FOIACommunication.objects.select_related(
+                        "from_user__profile__agency"
+                    ).preload_list(),
+                ),
+            ),
+            agency__jurisdiction__slug=self.kwargs["jurisdiction"],
+            agency__jurisdiction__pk=self.kwargs["jidx"],
+            slug=self.kwargs["slug"],
+            pk=self.kwargs["idx"],
+        )
+        valid_access_key = (
+            compare_digest(self.request.GET.get("key", ""), foia.access_key)
+            and foia.access_key != ""
+        )
+        if not foia.has_perm(self.request.user, "view") and not valid_access_key:
+            raise Http404()
+        return foia
+
+
 class MultiDetail(DetailView):
     """Detail view for multi requests"""
 

--- a/muckrock/templates/foia/detail/actions.html
+++ b/muckrock/templates/foia/detail/actions.html
@@ -151,10 +151,15 @@
         </form>
       {% endif %}
     {% endfor %}
-
     {% if not is_agency_user %}
       {% include "gethelp/_trigger_button.html" %}
     {% endif %}
+    <a
+      class="button print-action"
+      href="{% url "foia-detail-print" jurisdiction=foia.jurisdiction.slug jidx=foia.jurisdiction.pk idx=foia.id slug=foia.slug %}"
+      target="_blank"
+      rel="noopener"
+    >Print</a>
   </section>
 
 {% else %} {# unauthenticated #}

--- a/muckrock/templates/foia/detail_print.html
+++ b/muckrock/templates/foia/detail_print.html
@@ -1,0 +1,155 @@
+{% load static %}
+{% load tags %}
+{% load django_vite %}
+<!doctype html>
+<html lang="en-US">
+  <head>
+    <meta charset="utf-8" />
+    <title>{{ foia.title }} &bull; MuckRock</title>
+    <meta name="robots" content="noindex" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <style type="text/css">
+      @font-face {
+        font-family: 'Source Sans Pro';
+        src: url("{% static 'fonts/SourceSansPro-Regular.ttf' %}");
+        font-weight: 400;
+        font-style: normal;
+      }
+      @font-face {
+        font-family: 'Source Sans Pro';
+        src: url("{% static 'fonts/SourceSansPro-Italic.ttf' %}");
+        font-weight: 400;
+        font-style: italic;
+      }
+      @font-face {
+        font-family: 'Source Sans Pro';
+        src: url("{% static 'fonts/SourceSansPro-Semibold.ttf' %}");
+        font-weight: 500 600;
+        font-style: normal;
+      }
+      @font-face {
+        font-family: 'Source Sans Pro';
+        src: url("{% static 'fonts/SourceSansPro-SemiboldItalic.ttf' %}");
+        font-weight: 500 600;
+        font-style: italic;
+      }
+      @font-face {
+        font-family: 'Source Code Pro';
+        src: url("{% static 'fonts/SourceCodePro-Regular.ttf' %}");
+        font-weight: normal;
+        font-style: normal;
+      }
+    </style>
+    {% vite_asset 'muckrock/assets/print.js' %}
+  </head>
+  <body class="print">
+    <article class="request-print">
+      <header class="request-print__header">
+        <p class="request-print__brand">
+          MuckRock Request
+        </p>
+        <h1 class="request-print__title">{{ foia.title }}</h1>
+        <p class="request-print__subtitle">
+          {{ foia.composer.user.profile.full_name }}
+          filed this request with the
+          {{ foia.agency.name }}
+          of
+          {% if foia.jurisdiction.level == "f" %}the {% endif %}
+          {{ foia.jurisdiction.name }}{% if foia.jurisdiction.parent and foia.jurisdiction.level == "l" %}, {{ foia.jurisdiction.parent.name }}{% endif %}.
+        </p>
+        <dl class="request-print__meta">
+          <dt>MuckRock #</dt>
+          <dd>{{ foia.id }}</dd>
+          {% if foia.tracking_ids.all %}
+            <dt>Tracking #</dt>
+            <dd>
+              {% for tracking_id in foia.tracking_ids.all %}
+                {{ tracking_id }}{% if not forloop.last %}, {% endif %}
+              {% endfor %}
+            </dd>
+          {% endif %}
+          <dt>Status</dt>
+          <dd>{{ foia.get_status_display }}</dd>
+          <dt>Submitted</dt>
+          <dd>{{ foia.composer.datetime_submitted|date:"F j, Y" }}</dd>
+          {% if foia.date_due %}
+            <dt>Due</dt>
+            <dd>{{ foia.date_due|date:"F j, Y" }}</dd>
+          {% endif %}
+          {% if foia.date_estimate %}
+            <dt>Est. Completion</dt>
+            <dd>{{ foia.date_estimate|date:"F j, Y" }}</dd>
+          {% endif %}
+          <dt>Permalink</dt>
+          <dd>{{ request.scheme }}://{{ request.get_host }}{{ foia.get_absolute_url }}</dd>
+        </dl>
+      </header>
+
+      <section class="request-print__communications">
+        {% for communication in foia.communications.all %}
+          {% if not communication.hidden %}
+            <article class="request-print__communication {% if communication.response %}is-response{% else %}is-outgoing{% endif %}">
+              <header class="request-print__communication-header">
+                <p class="request-print__communication-from">
+                  <span class="request-print__label">From:</span>
+                  {{ communication.from_line }}
+                </p>
+                {% with to=communication.sent_to %}
+                  {% if to %}
+                    <p class="request-print__communication-to">
+                      <span class="request-print__label">To:</span>
+                      {{ to|stringformat:"s"|cut:" (error)" }}
+                    </p>
+                  {% endif %}
+                {% endwith %}
+                {% with delivered=communication.get_delivered %}
+                  {% if delivered %}
+                    <p class="request-print__communication-delivery">
+                      <span class="request-print__label">Via:</span>
+                      {{ delivered|capfirst }}
+                    </p>
+                  {% endif %}
+                {% endwith %}
+                <p class="request-print__communication-subject">
+                  <span class="request-print__label">Subject:</span>
+                  {{ communication.subject|default:"None" }}
+                </p>
+                <p class="request-print__communication-date">
+                  <span class="request-print__label">Date:</span>
+                  <time datetime="{{ communication.datetime|date:'c' }}">
+                    {{ communication.datetime|date:"F j, Y, g:i a" }}
+                  </time>
+                </p>
+              </header>
+              <div class="request-print__communication-body">
+                {% if communication.full_html %}
+                  {{ communication.communication|redact_emails|safe }}
+                {% else %}
+                  {{ communication.communication|redact_emails|linebreaks }}
+                {% endif %}
+              </div>
+            </article>
+          {% endif %}
+        {% endfor %}
+      </section>
+
+      <footer class="request-print__footer">
+        <p>
+          Printed from MuckRock on {% now "F j, Y" %}.
+          Visit
+          {{ request.scheme }}://{{ request.get_host }}{{ foia.get_absolute_url }}
+          for the latest version of this request.
+        </p>
+      </footer>
+    </article>
+    <script>
+      // Trigger the print dialog as soon as styles and layout are ready.
+      // The `noprint` query param lets people open the page without it.
+      if (!new URLSearchParams(window.location.search).has("noprint")) {
+        window.addEventListener("load", function () {
+          window.print();
+        });
+      }
+    </script>
+  </body>
+</html>

--- a/vite.config.js
+++ b/vite.config.js
@@ -20,6 +20,7 @@ export default defineConfig({
         foiamachine: path.resolve(__dirname, "muckrock/foiamachine/assets/entry.js"),
         docViewer: path.resolve(__dirname, "muckrock/assets/js/docViewer.js"),
         getHelp: path.resolve(__dirname, "muckrock/assets/js/getHelp.ts"),
+        print: path.resolve(__dirname, "muckrock/assets/print.js"),
       },
     },
   },


### PR DESCRIPTION
Fixes #2118

Adds a new `detail_print.html` template and dedicated `print.scss` stylesheet, presenting printable requests that omit much of the "application" to just focus on the request itself.

[2016 Clown Sightings (Portland Police Bureau) • MuckRock.pdf](https://github.com/user-attachments/files/28325913/2016.Clown.Sightings.Portland.Police.Bureau.MuckRock.pdf)
