### PR TITLE
remove q and a from the site

### DIFF
--- a/muckrock/accounts/tasks.py
+++ b/muckrock/accounts/tasks.py
@@ -591,7 +591,6 @@ def db_cleanup():
             "crowdfund",
             "accounts",
             "organization",
-            "qanda",
         ]
         for cleanup in revision_cleanup:
             call_command("deleterevisions", cleanup, days=180, verbosity=2)

--- a/muckrock/accounts/tests/test_views.py
+++ b/muckrock/accounts/tests/test_views.py
@@ -32,7 +32,6 @@ from muckrock.core.test_utils import (
 from muckrock.core.utils import new_action, notify
 from muckrock.foia.factories import FOIAComposerFactory, FOIARequestFactory
 from muckrock.foia.views import Detail as FOIARequestDetail
-from muckrock.qanda.views import Detail as QuestionDetail
 
 
 def http_get_post(url, view, data):

--- a/muckrock/accounts/tests/test_views.py
+++ b/muckrock/accounts/tests/test_views.py
@@ -17,12 +17,7 @@ import pytest
 
 # MuckRock
 from muckrock.accounts import views
-from muckrock.core.factories import (
-    AgencyFactory,
-    NotificationFactory,
-    QuestionFactory,
-    UserFactory,
-)
+from muckrock.core.factories import AgencyFactory, NotificationFactory, UserFactory
 from muckrock.core.test_utils import (
     http_get_response,
     http_post_response,
@@ -31,7 +26,6 @@ from muckrock.core.test_utils import (
 from muckrock.core.utils import new_action, notify
 from muckrock.foia.factories import FOIAComposerFactory, FOIARequestFactory
 from muckrock.foia.views import Detail as FOIARequestDetail
-from muckrock.qanda.views import Detail as QuestionDetail
 
 
 def http_get_post(url, view, data):
@@ -237,27 +231,6 @@ class TestNotificationRead(TestCase):
             jurisdiction=foia.jurisdiction.slug,
         )
         assert response.status_code == 200, "The view should response 200 OK."
-        # Check that the notification has been read.
-        notification.refresh_from_db()
-        assert notification.read, "The notification should be marked as read."
-
-    def test_get_question(self):
-        """Try getting the detail page for a Question with an unread notification."""
-        question = QuestionFactory()
-        view = QuestionDetail.as_view()
-        # Create a notification for the question
-        action = new_action(UserFactory(), "answered", target=question)
-        notification = notify(self.user, action)[0]
-        assert not notification.read, "The notification should be unread."
-        # Try getting the view as the user
-        response = http_get_response(
-            question.get_absolute_url(),
-            view,
-            self.user,
-            pk=question.pk,
-            slug=question.slug,
-        )
-        assert response.status_code == 200, "The view should respond 200 OK."
         # Check that the notification has been read.
         notification.refresh_from_db()
         assert notification.read, "The notification should be marked as read."

--- a/muckrock/accounts/tests/test_views.py
+++ b/muckrock/accounts/tests/test_views.py
@@ -8,6 +8,7 @@ from django.contrib.auth.models import AnonymousUser
 from django.http.response import Http404
 from django.test import RequestFactory, TestCase
 from django.urls import reverse
+from django.urls.exceptions import NoReverseMatch
 
 # Standard Library
 from unittest.mock import patch
@@ -17,7 +18,12 @@ import pytest
 
 # MuckRock
 from muckrock.accounts import views
-from muckrock.core.factories import AgencyFactory, NotificationFactory, UserFactory
+from muckrock.core.factories import (
+    AgencyFactory,
+    NotificationFactory,
+    QuestionFactory,
+    UserFactory,
+)
 from muckrock.core.test_utils import (
     http_get_response,
     http_post_response,
@@ -26,6 +32,7 @@ from muckrock.core.test_utils import (
 from muckrock.core.utils import new_action, notify
 from muckrock.foia.factories import FOIAComposerFactory, FOIARequestFactory
 from muckrock.foia.views import Detail as FOIARequestDetail
+from muckrock.qanda.views import Detail as QuestionDetail
 
 
 def http_get_post(url, view, data):
@@ -234,3 +241,9 @@ class TestNotificationRead(TestCase):
         # Check that the notification has been read.
         notification.refresh_from_db()
         assert notification.read, "The notification should be marked as read."
+
+    def test_get_question(self):
+        """Questions have been removed - ensure they do not have an accessible URL"""
+        question = QuestionFactory()
+        with pytest.raises(NoReverseMatch):
+            question.get_absolute_url()

--- a/muckrock/core/urls.py
+++ b/muckrock/core/urls.py
@@ -31,7 +31,6 @@ import muckrock.news.viewsets
 import muckrock.organization.api_v2.viewsets
 import muckrock.project.api_v2.viewsets
 import muckrock.project.viewsets
-import muckrock.qanda.views
 import muckrock.task.viewsets
 from muckrock.agency.sitemap import AgencySitemap
 from muckrock.core import views
@@ -42,7 +41,6 @@ from muckrock.foia.views.communications import FOIACommunicationDirectAgencyView
 from muckrock.jurisdiction.sitemap import JurisdictionSitemap
 from muckrock.news.sitemap import ArticleSitemap
 from muckrock.project.sitemap import ProjectSitemap
-from muckrock.qanda.sitemap import QuestionSitemap
 
 admin.site.index_template = "admin/custom_index.html"
 
@@ -51,7 +49,6 @@ sitemaps = {
     "News": ArticleSitemap,
     "Agency": AgencySitemap,
     "Jurisdiction": JurisdictionSitemap,
-    "Question": QuestionSitemap,
     "Project": ProjectSitemap,
     "Flatpages": FlatPageSitemap,
 }
@@ -154,7 +151,6 @@ urlpatterns = [
     re_path(r"^agency/", include("muckrock.agency.urls")),
     re_path(r"^place/", include(muckrock.jurisdiction.urls.urlpatterns)),
     re_path(r"^jurisdiction/", include(muckrock.jurisdiction.urls.old_urlpatterns)),
-    re_path(r"^questions/", include("muckrock.qanda.urls")),
     re_path(r"^crowdfund/", include("muckrock.crowdfund.urls")),
     re_path(r"^assignment/", include("muckrock.crowdsource.urls")),
     re_path(r"^task/", include("muckrock.task.urls")),

--- a/muckrock/message/digests.py
+++ b/muckrock/message/digests.py
@@ -32,7 +32,6 @@ from muckrock.core.models import ExtractDay
 from muckrock.crowdfund.models import Crowdfund
 from muckrock.foia.models import FOIACommunication, FOIARequest
 from muckrock.message.email import TemplateEmail
-from muckrock.qanda.models import Question
 
 logger = logging.getLogger(__name__)
 
@@ -128,7 +127,6 @@ class ActivityDigest(Digest):
     activity = {
         "count": 0,
         "requests": {"count": 0, "mine": None, "following": None},
-        "questions": {"count": 0, "mine": None, "following": None},
     }
 
     # Most of the work re: composing the email takes place
@@ -184,12 +182,7 @@ class ActivityDigest(Digest):
             .filter(datetime__gte=duration)
         )
         self.activity["requests"] = self.foia_notifications(notifications)
-        self.activity["questions"] = self.notifications_for_model(
-            notifications, Question
-        )
-        self.activity["count"] = (
-            self.activity["requests"]["count"] + self.activity["questions"]["count"]
-        )
+        self.activity["count"] = self.activity["requests"]["count"]
         return self.activity
 
     def foia_notifications(self, notifications):

--- a/muckrock/message/tests/test_digests.py
+++ b/muckrock/message/tests/test_digests.py
@@ -20,7 +20,6 @@ from dateutil.relativedelta import relativedelta
 from muckrock.core.factories import (
     AgencyFactory,
     AnswerFactory,
-    QuestionFactory,
     StatisticsFactory,
     UserFactory,
 )
@@ -75,43 +74,6 @@ class TestDailyDigest(TestCase):
         # generate the email, which should contain the generated action
         email = self.digest(user=self.user, interval=self.interval)
         assert email.activity["count"] == 1, "There should be activity."
-        assert email.send() == 1, "The email should send."
-
-    def test_digest_user_questions(self):
-        """Digests should include information on questions I asked."""
-        # generate an action on a question the user asked
-        question = QuestionFactory(user=self.user)
-        other_user = UserFactory()
-        AnswerFactory(user=other_user, question=question)
-        # creating an answer _should_ have created a notification
-        # so let's generate the email and see what happened
-        email = self.digest(user=self.user, interval=self.interval)
-        assert (
-            email.activity["count"] == 1
-        ), "There should be activity that is not user initiated."
-        assert email.activity["questions"]["mine"].first().action.actor == other_user
-        assert email.activity["questions"]["mine"].first().action.verb == "answered"
-        assert email.send() == 1, "The email should send."
-
-    def test_digest_follow_questions(self):
-        """Digests should include information on questions I follow."""
-        # generate an action on a question that I follow
-        question = QuestionFactory()
-        follow(self.user, question, actor_only=False)
-        other_user = UserFactory()
-        answer = AnswerFactory(user=other_user, question=question)
-        email = self.digest(user=self.user, interval=self.interval)
-        assert email.activity["count"] == 1, "There should be activity."
-        assert (
-            email.activity["questions"]["following"].first().action.actor == other_user
-        )
-        assert (
-            email.activity["questions"]["following"].first().action.action_object
-            == answer
-        )
-        assert (
-            email.activity["questions"]["following"].first().action.target == question
-        )
         assert email.send() == 1, "The email should send."
 
 

--- a/muckrock/message/tests/test_digests.py
+++ b/muckrock/message/tests/test_digests.py
@@ -13,10 +13,17 @@ from unittest.mock import Mock, patch
 
 # Third Party
 import pytest
+from actstream.actions import follow
 from dateutil.relativedelta import relativedelta
 
 # MuckRock
-from muckrock.core.factories import AgencyFactory, StatisticsFactory, UserFactory
+from muckrock.core.factories import (
+    AgencyFactory,
+    AnswerFactory,
+    QuestionFactory,
+    StatisticsFactory,
+    UserFactory,
+)
 from muckrock.core.utils import new_action, notify
 from muckrock.foia.factories import FOIARequestFactory
 from muckrock.message import digests
@@ -69,6 +76,33 @@ class TestDailyDigest(TestCase):
         email = self.digest(user=self.user, interval=self.interval)
         assert email.activity["count"] == 1, "There should be activity."
         assert email.send() == 1, "The email should send."
+
+    def test_digest_user_questions(self):
+        """Digests should not include information on questions I asked."""
+        # generate an action on a question the user asked
+        question = QuestionFactory(user=self.user)
+        other_user = UserFactory()
+        AnswerFactory(user=other_user, question=question)
+        # creating an answer _should_ not have created a notification
+        # so let's generate the email and see what happened
+        email = self.digest(user=self.user, interval=self.interval)
+        assert email.activity["count"] == 0
+        assert "questions" not in email.activity
+        # email does not send if there is no activity
+        assert email.send() == 0, "The email should not send."
+
+    def test_digest_follow_questions(self):
+        """Digests should not include information on questions I follow."""
+        # generate an action on a question that I follow
+        question = QuestionFactory()
+        follow(self.user, question, actor_only=False)
+        other_user = UserFactory()
+        answer = AnswerFactory(user=other_user, question=question)
+        email = self.digest(user=self.user, interval=self.interval)
+        assert email.activity["count"] == 0
+        assert "questions" not in email.activity
+        # email does not send if there is no activity
+        assert email.send() == 0, "The email should not send."
 
 
 class TestStaffDigest(TestCase):

--- a/muckrock/message/tests/test_digests.py
+++ b/muckrock/message/tests/test_digests.py
@@ -97,7 +97,7 @@ class TestDailyDigest(TestCase):
         question = QuestionFactory()
         follow(self.user, question, actor_only=False)
         other_user = UserFactory()
-        answer = AnswerFactory(user=other_user, question=question)
+        AnswerFactory(user=other_user, question=question)
         email = self.digest(user=self.user, interval=self.interval)
         assert email.activity["count"] == 0
         assert "questions" not in email.activity

--- a/muckrock/message/tests/test_digests.py
+++ b/muckrock/message/tests/test_digests.py
@@ -13,16 +13,10 @@ from unittest.mock import Mock, patch
 
 # Third Party
 import pytest
-from actstream.actions import follow
 from dateutil.relativedelta import relativedelta
 
 # MuckRock
-from muckrock.core.factories import (
-    AgencyFactory,
-    AnswerFactory,
-    StatisticsFactory,
-    UserFactory,
-)
+from muckrock.core.factories import AgencyFactory, StatisticsFactory, UserFactory
 from muckrock.core.utils import new_action, notify
 from muckrock.foia.factories import FOIARequestFactory
 from muckrock.message import digests

--- a/muckrock/qanda/tests.py
+++ b/muckrock/qanda/tests.py
@@ -13,6 +13,7 @@ from muckrock.core.test_utils import mock_middleware
 from muckrock.qanda.views import QuestionList, block_user, report_spam
 
 
+@pytest.mark.skip("deprecated")
 class TestQandA(TestCase):
     """Test for Q&A"""
 

--- a/muckrock/qanda/tests.py
+++ b/muckrock/qanda/tests.py
@@ -7,6 +7,9 @@ from django.core import mail
 from django.test import RequestFactory, TestCase
 from django.urls import reverse
 
+# Third Party
+import pytest
+
 # MuckRock
 from muckrock.core.factories import AnswerFactory, QuestionFactory, UserFactory
 from muckrock.core.test_utils import mock_middleware

--- a/muckrock/tags/views.py
+++ b/muckrock/tags/views.py
@@ -11,7 +11,6 @@ from muckrock.core.views import MRAutocompleteView
 from muckrock.foia.models import FOIARequest
 from muckrock.news.models import Article
 from muckrock.project.models import Project
-from muckrock.qanda.models import Question
 from muckrock.tags.forms import TagForm
 from muckrock.tags.models import Tag
 
@@ -78,11 +77,6 @@ class TagDetailView(DetailView):
             Article.objects.get_published()
             .filter(tags=this_tag)
             .prefetch_related("authors", "authors__profile", "projects"),
-        )
-        self._get_and_count(
-            context,
-            "tagged_questions",
-            Question.objects.filter(tags__name__in=[this_tag]),
         )
         return context
 

--- a/muckrock/templates/message/digest/digest.html
+++ b/muckrock/templates/message/digest/digest.html
@@ -37,25 +37,6 @@
         {% endif %}
         {% endwith %}
     {% endif %}
-    {% if activity.questions.count > 0 %}
-        <h1>Questions</h1>
-        {% if activity.questions.mine|length > 0 %}
-        <h2>Yours</h2>
-        <ul>
-            {% for notification in activity.questions.mine %}
-            <li>{% display_passive_action notification.action %}</li>
-            {% endfor %}
-        </ul>
-        {% endif %}
-        {% if activity.questions.following|length > 0 %}
-        <h2>Following</h2>
-        <ul>
-            {% for notification in activity.questions.following %}
-            <li>{% display_passive_action notification.action %}</li>
-            {% endfor %}
-        </ul>
-        {% endif %}
-    {% endif %}
 {% endblock body %}
 
 {% block settings %}

--- a/muckrock/templates/message/digest/digest.txt
+++ b/muckrock/templates/message/digest/digest.txt
@@ -30,29 +30,6 @@ Following
 {% include 'message/component/foia_digest.txt' with notifications=follow_foia.received label='New Response' %}
 {% endif %}{% endwith %}
 {% endif %}
-{% if activity.questions.count > 0 %}
----------------------------
-Questions
-- - - - - - - - - - - - - -
-{% if activity.questions.mine|length > 0 %}
-Yours
-- - - - - - - - - - - - - -
-{% for notification in activity.questions.mine %}
-{% with notification.action as action %}
-* {% include 'lib/pattern/actions/passive.txt' %}
-{% endwith %}
-{% endfor %}
-{% endif %}
-{% if activity.questions.following|length > 0 %}
-Following
-- - - - - - - - - - - - - -
-{% for notification in activity.questions.following %}
-{% with notification.action as action %}
-* {% include 'lib/pattern/actions/passive.txt' %}
-{% endwith %}
-{% endfor %}
-{% endif %}
-{% endif %}
 {% endblock %}
 
 {% block settings %}

--- a/muckrock/templates/nav/footer.html
+++ b/muckrock/templates/nav/footer.html
@@ -62,7 +62,6 @@
                 <dfn>Feeds</dfn>
                 <ul>
                     <li><a href="{% url 'news-feed' %}">Latest Reporting</a></li>
-                    <li><a href="{% url 'question-feed' %}">Latest Questions</a></li>
                     <li><a href="{% url 'foia-submitted-feed' %}">Recently Filed Requests</a></li>
                     <li><a href="{% url 'foia-done-feed' %}">Recently Completed Requests</a></li>
                 </ul>

--- a/muckrock/templates/search/search.html
+++ b/muckrock/templates/search/search.html
@@ -17,10 +17,6 @@
         <input type="checkbox" id="id_models_1_show" {% if foia_checked %}checked="checked"{% endif %}/>
         <label for="id_models_1_show">Requests</label>
     </li>
-    <li>
-        <input type="checkbox" id="id_models_2_show" {% if qanda_checked %}checked="checked"{% endif %}/>
-        <label for="id_models_2_show">Questions</label>
-    </li>
 </ul>
 {% endblock list-navigation %}
 
@@ -34,7 +30,6 @@
             <div style="display: none">
                 <input type="checkbox" name="models" value="news.article" id="id_models_0" {% if news_checked %}checked="checked"{% endif %} />
                 <input type="checkbox" name="models" value="foia.foiarequest" id="id_models_1" {% if foia_checked %}checked="checked"{% endif %} />
-                <input type="checkbox" name="models" value="qanda.question" id="id_models_2" {% if qanda_checked %}checked="checked"{% endif %}/>
             </div>
         </form>
     </section>
@@ -55,8 +50,6 @@
                     Request
                     {% elif item.model_name == "article" %}
                     Article
-                    {% elif item.model_name == "question" %}
-                    Question
                     {% endif %}
                 </td>
                 <td><a href="{{ item.object.get_absolute_url }}">{{ item.object }}</a></td>

--- a/muckrock/templates/tags/tag_list.html
+++ b/muckrock/templates/tags/tag_list.html
@@ -38,15 +38,6 @@
             {% include 'lib/foia.html' %}
         {% endfor %}
         {% endif %}
-        {% if tagged_questions %}
-        <h2>{{ tagged_questions_count }} Question{{ tagged_questions_count|pluralize }}</h2>
-        <p><a href="{% url "question-index" %}?tags={{ tag.pk }}">View all...</a></p>
-        <table>
-            {% for question in tagged_questions %}
-            <tr><td><a href="{{ question.get_absolute_url }}">{{ question.title }}</a></td></tr>
-            {% endfor %}
-        </table>
-        {% endif %}
     </section>
     {% else %}
     <section class="no-tag detail">


### PR DESCRIPTION
Remove all ways of viewing Q&A section from the site, and remove question data from digests.

Data is left in the system in case it is needed for future usage.