### PR TITLE
Speed up tests

### DIFF
--- a/muckrock/foiamachine/tests/test_forms.py
+++ b/muckrock/foiamachine/tests/test_forms.py
@@ -56,7 +56,7 @@ class TestFoiaMachineRequestForm(TestCase):
     def test_agency_mismatch(self):
         """The form should not validate if the agency is from a different
         jurisdiction."""
-        jurisdiction = StateJurisdictionFactory()
+        jurisdiction = StateJurisdictionFactory(name="California")
         form = forms.FoiaMachineRequestForm(
             {
                 "title": self.title,

--- a/muckrock/jurisdiction/factories.py
+++ b/muckrock/jurisdiction/factories.py
@@ -23,6 +23,7 @@ class FederalJurisdictionFactory(factory.django.DjangoModelFactory):
 
     class Meta:
         model = Jurisdiction
+        django_get_or_create = ("name", "level")
 
     name = "United States of America"
     abbrev = "USA"
@@ -38,6 +39,7 @@ class StateJurisdictionFactory(factory.django.DjangoModelFactory):
 
     class Meta:
         model = Jurisdiction
+        django_get_or_create = ("name", "level")
 
     name = "Massachusetts"
     abbrev = "MA"
@@ -68,6 +70,7 @@ class LawFactory(factory.django.DjangoModelFactory):
 
     class Meta:
         model = Law
+        django_get_or_create = ("jurisdiction",)
 
     jurisdiction = factory.SubFactory(StateJurisdictionFactory, law=None)
     name = "Massachusetts Public Records Law"

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,3 @@
 [pytest]
-addopts = --ds=muckrock.settings.test --import-mode=importlib --ignore=muckrock/gloo 
+addopts = --ds=muckrock.settings.test --import-mode=importlib --ignore=muckrock/gloo --reuse-db
 python_files = tests.py test_*.py


### PR DESCRIPTION
This enables db reuse by default (I am not sure why it wasn't the default already) which speeds up tests considerably.  There is also a change for factories to reuse models, which was a much more modest speed up.