### PR TITLE
Add tags to apiv2

### DIFF
--- a/muckrock/foia/api_v2/serializers.py
+++ b/muckrock/foia/api_v2/serializers.py
@@ -203,7 +203,7 @@ class FOIARequestCreateSerializer(serializers.ModelSerializer):
     )
 
     tags = serializers.ListField(
-        child=serializers.SlugField(max_length=100),
+        child=serializers.CharField(max_length=100),
         required=False,
         help_text="List of tags to apply to this request",
     )

--- a/muckrock/foia/api_v2/serializers.py
+++ b/muckrock/foia/api_v2/serializers.py
@@ -152,6 +152,7 @@ class FOIARequestSerializer(serializers.ModelSerializer):
             },
         }
 
+
 @extend_schema_serializer(
     examples=[
         OpenApiExample(

--- a/muckrock/foia/api_v2/serializers.py
+++ b/muckrock/foia/api_v2/serializers.py
@@ -83,6 +83,12 @@ class FOIARequestSerializer(serializers.ModelSerializer):
         ),
     )
 
+    tags = serializers.StringRelatedField(
+        many=True,
+        read_only=True,
+        help_text="Tags associated with this request",
+    )
+
     class Meta:
         """Filters for foia request search"""
 
@@ -107,7 +113,7 @@ class FOIARequestSerializer(serializers.ModelSerializer):
             "tracking_id",
             "price",
             # connected models
-            # "tags",
+            "tags",
             # "notes",
             # "communications",
             "edited_boilerplate",
@@ -145,7 +151,6 @@ class FOIARequestSerializer(serializers.ModelSerializer):
                 "help_text": "The cost of processing this request, if applicable"
             },
         }
-
 
 @extend_schema_serializer(
     examples=[
@@ -196,6 +201,12 @@ class FOIARequestCreateSerializer(serializers.ModelSerializer):
         help_text="Description of the documents being requested"
     )
 
+    tags = serializers.ListField(
+        child=serializers.SlugField(max_length=100),
+        required=False,
+        help_text="List of tags to apply to this request",
+    )
+
     class Meta:
         """Filters for foia request create"""
 
@@ -209,7 +220,7 @@ class FOIARequestCreateSerializer(serializers.ModelSerializer):
             # "attachments",
             # "edit_collaborators",
             # "read_collaborators",
-            # "tags",
+            "tags",
         )
         extra_kwargs = {
             "embargo_status": {

--- a/muckrock/foia/api_v2/viewsets.py
+++ b/muckrock/foia/api_v2/viewsets.py
@@ -83,7 +83,7 @@ class FOIARequestViewSet(
             tags = request.data.get("tags", [])
             if tags:
                 for foia in foias:
-                    foia.tags.set(*tags)
+                    foia.tags.set(tags)
             return Response(
                 {
                     "status": "FOI Request submitted",

--- a/muckrock/foia/api_v2/viewsets.py
+++ b/muckrock/foia/api_v2/viewsets.py
@@ -50,7 +50,7 @@ class FOIARequestViewSet(
             FOIARequest.objects.get_viewable(self.request.user)
             .select_related("composer")
             .prefetch_related(
-                "edit_collaborators", "read_collaborators", "tracking_ids"
+                "edit_collaborators", "read_collaborators", "tracking_ids", "tags"
             )
         )
 
@@ -78,14 +78,20 @@ class FOIARequestViewSet(
                 },
                 status=http_status.HTTP_402_PAYMENT_REQUIRED,
             )
-        return Response(
-            {
-                "status": "FOI Request submitted",
-                "location": composer.get_absolute_url(),
-                "requests": [f.pk for f in composer.foias.all()],
-            },
-            status=http_status.HTTP_201_CREATED,
-        )
+        else:
+            foias = list(composer.foias.all())
+            tags = request.data.get("tags", [])
+            if tags:
+                for foia in foias:
+                    foia.tags.set(*tags)
+            return Response(
+                {
+                    "status": "FOI Request submitted",
+                    "location": composer.get_absolute_url(),
+                    "requests": [f.pk for f in foias],
+                },
+                status=http_status.HTTP_201_CREATED,
+            )
 
     class Filter(django_filters.FilterSet):
         """Filters for requests"""


### PR DESCRIPTION
Shows you tags in list view also allows you to specify them when you file a request. 

- Verified only 1 more SQL query is made in list view compared to current MuckRock staging (which shows the debug toolbar 24 vs. 23 queries)
https://muckrock-staging.herokuapp.com/api_v2/requests/
- Verified existing tags filter is performant. 
- Add the ability to set tags on creation. Verified it works too, specifically with tags that contain whitespace

<img width="475" height="872" alt="image" src="https://github.com/user-attachments/assets/9977e5e4-5000-4c07-8dd9-79116390e7ca" />

Closes #2161 
