### PR TITLE
Fix routing for staging and deploy previews for exemption search

### DIFF
--- a/muckrock/assets/js/exemptionBrowser/api.js
+++ b/muckrock/assets/js/exemptionBrowser/api.js
@@ -4,16 +4,7 @@
 
 import Cookie from "js-cookie";
 
-/* eslint-disable no-undef */
-let rootDomain = "https://dev.muckrock.com";
-if (process.env.NODE_ENV == "staging") {
-  rootDomain = "https://muckrock-staging.herokuapp.com";
-} else if (process.env.NODE_ENV == "production") {
-  rootDomain = "https://www.muckrock.com";
-}
-/* eslint-enable no-undef */
-
-const baseURL = rootDomain + "/api_v1/";
+const baseURL = "/api_v1/";
 
 async function request(method, path, { params, body } = {}) {
   const url = new URL(path, baseURL);
@@ -47,4 +38,4 @@ const api = {
   post: (path, body) => request("POST", path, { body }),
 };
 
-export { api as default, rootDomain };
+export default api;

--- a/muckrock/assets/js/exemptionBrowser/api.js
+++ b/muckrock/assets/js/exemptionBrowser/api.js
@@ -1,13 +1,20 @@
 // Fetch-based client for /api_v1/. Returns { data, status } on success and
 // throws with err.response.{data, status} on non-2xx — the shape actions.js
 // callers depend on.
-
 import Cookie from "js-cookie";
 
 const baseURL = "/api_v1/";
 
+function buildURL(path) {
+  const base =
+    typeof window !== "undefined"
+      ? window.location.origin + baseURL
+      : "http://localhost" + baseURL;
+  return new URL(path, base);
+}
+
 async function request(method, path, { params, body } = {}) {
-  const url = new URL(path, baseURL);
+  const url = buildURL(path);
   if (params) {
     for (const [key, value] of Object.entries(params)) {
       url.searchParams.set(key, value);

--- a/muckrock/assets/js/exemptionBrowser/api.test.js
+++ b/muckrock/assets/js/exemptionBrowser/api.test.js
@@ -5,7 +5,7 @@ vi.mock("js-cookie", () => ({
 }));
 
 import Cookie from "js-cookie";
-import api, { rootDomain } from "./api";
+import api from "./api";
 
 const jsonResponse = (data, { ok = true, status = 200 } = {}) => ({
   ok,
@@ -23,20 +23,13 @@ describe("api transport", () => {
     vi.unstubAllGlobals();
   });
 
-  describe("rootDomain", () => {
-    it("defaults to dev.muckrock.com when not in staging or production", () => {
-      // process.env.NODE_ENV is unset (or "test") in vitest, so we get the default branch.
-      expect(rootDomain).toBe("https://dev.muckrock.com");
-    });
-  });
-
   describe("get()", () => {
     it("requests baseURL + path with no query string when no params given", async () => {
       fetch.mockResolvedValue(jsonResponse({ results: [] }));
       await api.get("exemption/");
       expect(fetch).toHaveBeenCalledTimes(1);
       const [url] = fetch.mock.calls[0];
-      expect(String(url)).toBe("https://dev.muckrock.com/api_v1/exemption/");
+      expect(String(url)).toBe("http://localhost/api_v1/exemption/");
     });
 
     it("appends params as a URL-encoded query string", async () => {
@@ -46,7 +39,7 @@ describe("api transport", () => {
       });
       const [url] = fetch.mock.calls[0];
       expect(String(url)).toBe(
-        "https://dev.muckrock.com/api_v1/exemption/?q=foo+bar&jurisdiction=1",
+        "http://localhost/api_v1/exemption/?q=foo+bar&jurisdiction=1",
       );
     });
 
@@ -82,7 +75,7 @@ describe("api transport", () => {
       await api.post("exemption/submit/", { foia: 7, language: "en" });
       const [url, init] = fetch.mock.calls[0];
       expect(String(url)).toBe(
-        "https://dev.muckrock.com/api_v1/exemption/submit/",
+        "http://localhost/api_v1/exemption/submit/",
       );
       expect(init.method).toBe("POST");
       expect(init.body).toBe(JSON.stringify({ foia: 7, language: "en" }));

--- a/muckrock/assets/js/exemptionBrowser/components/ExemptionDetail.jsx
+++ b/muckrock/assets/js/exemptionBrowser/components/ExemptionDetail.jsx
@@ -6,7 +6,6 @@
 import $ from 'jquery';
 import React, { PropTypes } from 'react';
 
-import { rootDomain } from '../api';
 
 const AppealLanguage = ({appeal}) => {
     const handleClick = (e) => {


### PR DESCRIPTION
As mentioned in feedback, API calls were firing to production and thus failing for CORS errors in the deploy preview for the axios swap. This was an existing bug before the swap away from axios was in place, as it currently affects muckrock staging. I dug around a bit and noticed NODE_ENV isn't actually defined anywhere, so it is a dead end. The browser lets us get our current origin so we should just use that. The URLs for the tests shouldn't matter, it is just testing logic. 