### PR TITLE
Gloo update

### DIFF
--- a/local.yml
+++ b/local.yml
@@ -22,8 +22,6 @@ services:
     env_file:
       - ./.envs/.local/.django
       - ./.envs/.local/.postgres
-    ports:
-      - "8000:80"
     command: /start
     networks:
       default:

--- a/pip/requirements.in
+++ b/pip/requirements.in
@@ -2,7 +2,7 @@
 -e git+https://github.com/MuckRock/django-opensearch.git@master#egg=django-opensearch # for opensearch.xml
 -e git+https://github.com/MuckRock/govqa-py@main#egg=govqa # for govqa integration
 aiohttp
-baml # For using gloo to use ChatGPT
+baml-py # For using gloo to use ChatGPT
 beautifulsoup4 # used for parsing html
 bleach # Used to sanitize any HTML we're rendering
 boto3 # Used to access AWS
@@ -64,6 +64,7 @@ pillow # Used by Django for image handling
 plaid-python # for access to bank account information
 psycopg2-binary # Interface to postgres DB
 pycryptodome # Reading encypted PDFs
+pydantic # for gloo
 pyjwkest # for oauth
 pymdown-extensions # Adds more helpful Markdown extensions
 pypdf # Used to manipulate PDFs

--- a/pip/requirements.txt
+++ b/pip/requirements.txt
@@ -13,22 +13,13 @@
 aiohappyeyeballs==2.6.1
     # via aiohttp
 aiohttp==3.13.3
-    # via
-    #   -r pip/requirements.in
-    #   baml
+    # via -r pip/requirements.in
 aiosignal==1.4.0
     # via aiohttp
 amqp==5.3.1
     # via kombu
-annotated-types==0.5.0
+annotated-types==0.7.0
     # via pydantic
-anthropic==0.23.1
-    # via baml
-anyio==4.2.0
-    # via
-    #   anthropic
-    #   httpx
-    #   openai
 asgiref==3.11.1
     # via
     #   django
@@ -39,14 +30,11 @@ attrs==23.1.0
     # via
     #   aiohttp
     #   jsonschema
-    #   pytest
     #   referencing
 backcall==0.2.0
     # via ipython
-baml==0.19.1
+baml-py==0.223.0
     # via -r pip/requirements.in
-baml-core-ffi==0.1.7
-    # via baml
 beautifulsoup4==4.13.4
     # via
     #   -r pip/requirements.in
@@ -72,8 +60,6 @@ celery==5.6.2
     #   sentry-sdk
 certifi==2024.7.4
     # via
-    #   httpcore
-    #   httpx
     #   phaxio
     #   requests
     #   scout-apm
@@ -98,10 +84,6 @@ click-plugins==1.1.1
     # via celery
 click-repl==0.2.0
     # via celery
-colorama==0.4.6
-    # via baml
-coloredlogs==15.0.1
-    # via baml
 cryptography==46.0.0
     # via
     #   google-auth
@@ -119,13 +101,7 @@ defusedxml==0.7.1
     #   python3-openid
     #   social-auth-core
 deprecated==1.2.14
-    # via
-    #   opentelemetry-api
-    #   pikepdf
-distro==1.9.0
-    # via
-    #   anthropic
-    #   openai
+    # via pikepdf
 django==5.2.12
     # via
     #   -r pip/requirements.in
@@ -243,16 +219,12 @@ executing==2.2.0
     # via stack-data
 fastjsonschema==2.19.1
     # via python-documentcloud
-filelock==3.20.3
-    # via huggingface-hub
 fpdf==1.7.2
     # via -r pip/requirements.in
 frozenlist==1.4.0
     # via
     #   aiohttp
     #   aiosignal
-fsspec==2023.12.2
-    # via huggingface-hub
 furl==1.0.1
     # via -r pip/requirements.in
 future==0.18.3
@@ -286,39 +258,18 @@ googleapis-common-protos==1.72.0
     # via google-api-core
 gunicorn==23.0.0
     # via -r pip/requirements.in
-h11==0.16.0
-    # via httpcore
-hf-xet==1.3.0
-    # via huggingface-hub
-httpcore==1.0.9
-    # via httpx
 httplib2==0.19.0
     # via
     #   google-api-python-client
     #   oauth2client
-httpx==0.27.0
-    # via
-    #   anthropic
-    #   ollama
-    #   openai
-huggingface-hub==0.36.2
-    # via tokenizers
-humanfriendly==10.0
-    # via coloredlogs
 idna==3.10
     # via
-    #   anyio
-    #   httpx
     #   requests
     #   yarl
 img2pdf==0.5.1
     # via -r pip/requirements.in
-importlib-metadata==6.11.0
-    # via opentelemetry-api
 inflection==0.5.1
     # via drf-spectacular
-iniconfig==2.0.0
-    # via pytest
 ipython==8.10.0
     # via -r pip/requirements.in
 jedi==0.19.2
@@ -327,8 +278,6 @@ jmespath==0.10.0
     # via
     #   boto3
     #   botocore
-json5==0.9.14
-    # via baml
 jsonfield==2.0.2
     # via -r pip/requirements.in
 jsonschema==4.21.1
@@ -374,32 +323,14 @@ oauthlib==3.3.1
     # via
     #   requests-oauthlib
     #   social-auth-core
-ollama==0.1.8
-    # via baml
-openai==1.16.2
-    # via baml
-opentelemetry-api==1.22.0
-    # via
-    #   baml
-    #   opentelemetry-instrumentation
-    #   opentelemetry-sdk
-opentelemetry-instrumentation==0.41b0
-    # via baml
-opentelemetry-sdk==1.22.0
-    # via baml
-opentelemetry-semantic-conventions==0.43b0
-    # via opentelemetry-sdk
 orderedmultidict==1.0.1
     # via furl
 packaging==23.2
     # via
-    #   baml
     #   bleach
     #   gunicorn
-    #   huggingface-hub
     #   kombu
     #   pikepdf
-    #   pytest
 parso==0.8.4
     # via jedi
 pdfrw==0.4
@@ -423,8 +354,6 @@ pillow==12.1.1
     #   reportlab
 plaid-python==3.4.0
     # via -r pip/requirements.in
-pluggy==1.3.0
-    # via pytest
 premailer==3.0.0
     # via django-premailer
 prompt-toolkit==3.0.31
@@ -451,8 +380,6 @@ ptyprocess==0.6.0
     # via pexpect
 pure-eval==0.2.3
     # via stack-data
-py==1.11.0
-    # via pytest
 pyasn1==0.4.2
     # via
     #   oauth2client
@@ -468,12 +395,9 @@ pycryptodome==3.18.0
     # via -r pip/requirements.in
 pycryptodomex==3.19.1
     # via pyjwkest
-pydantic==2.4.0
-    # via
-    #   anthropic
-    #   baml
-    #   openai
-pydantic-core==2.10.0
+pydantic==2.11.10
+    # via -r pip/requirements.in
+pydantic-core==2.33.2
     # via pydantic
 pygments==2.15.1
     # via ipython
@@ -489,12 +413,6 @@ pyparsing==2.4.7
     # via httplib2
 pypdf==6.8.0
     # via -r pip/requirements.in
-pytest==7.1.3
-    # via
-    #   baml
-    #   pytest-asyncio
-pytest-asyncio==0.21.1
-    # via baml
 python-dateutil==2.9.0
     # via
     #   botocore
@@ -505,8 +423,6 @@ python-dateutil==2.9.0
     #   zenpy
 python-documentcloud==4.1.0
     # via -r pip/requirements.in
-python-dotenv==1.0.1
-    # via baml
 python-levenshtein==0.25.1
     # via -r pip/requirements.in
 python-redis-lock[django]==3.7.0
@@ -520,7 +436,6 @@ pytz==2024.2
 pyyaml==6.0.1
     # via
     #   drf-spectacular
-    #   huggingface-hub
     #   pymdown-extensions
     #   python-documentcloud
 rapidfuzz==3.14.3
@@ -537,9 +452,7 @@ referencing==0.34.0
     #   jsonschema
     #   jsonschema-specifications
 regex==2023.12.25
-    # via
-    #   baml
-    #   tiktoken
+    # via tiktoken
 reportlab==4.4.1
     # via -r pip/requirements.in
 requests[security]==2.32.5
@@ -548,7 +461,6 @@ requests[security]==2.32.5
     #   django-anymail
     #   google-api-core
     #   google-cloud-storage
-    #   huggingface-hub
     #   lob
     #   logzio-python-handler
     #   phaxio
@@ -603,12 +515,6 @@ smart-open==1.10.0
     # via -r pip/requirements.in
 smartypants==1.8.6
     # via -r pip/requirements.in
-sniffio==1.3.0
-    # via
-    #   anthropic
-    #   anyio
-    #   httpx
-    #   openai
 social-auth-app-django==5.6.0
     # via -r pip/requirements.in
 social-auth-core==4.8.5
@@ -627,41 +533,22 @@ stack-data==0.6.3
     # via ipython
 stripe==8.11.0
     # via -r pip/requirements.in
-tenacity==8.2.3
-    # via baml
 tiktoken==0.12.0
     # via -r pip/requirements.in
-tokenizers==0.15.1
-    # via anthropic
-tomli==2.2.1
-    # via pytest
-tqdm==4.66.3
-    # via
-    #   huggingface-hub
-    #   openai
 traitlets==5.14.3
     # via
     #   ipython
     #   matplotlib-inline
-typeguard==4.1.5
-    # via baml
-types-regex==2023.12.25.20240106
-    # via baml
-types-requests==2.31.0.5
-    # via baml
-types-urllib3==1.26.25.14
-    # via types-requests
 typing-extensions==4.12.2
     # via
     #   aiosignal
-    #   anthropic
     #   beautifulsoup4
-    #   huggingface-hub
-    #   openai
-    #   opentelemetry-sdk
     #   pydantic
     #   pydantic-core
     #   stripe
+    #   typing-inspection
+typing-inspection==0.4.2
+    # via pydantic
 tzdata==2025.3
     # via kombu
 tzlocal==5.3.1
@@ -693,7 +580,6 @@ webencodings==0.5.1
 wrapt==1.17.2
     # via
     #   deprecated
-    #   opentelemetry-instrumentation
     #   scout-apm
 xlrd==1.1.0
     # via -r pip/requirements.in
@@ -701,8 +587,6 @@ yarl==1.23.0
     # via aiohttp
 zenpy==2.0.47
     # via -r pip/requirements.in
-zipp==3.19.1
-    # via importlib-metadata
 zipstream==1.1.4
     # via -r pip/requirements.in
 


### PR DESCRIPTION
The old `baml` package stopped working and needs to be updated to `baml-py`.  This is me throwing Claude at it.

I also updated to the new dashboard and sent out invites.

I updated the LLMs from GPT 3.5/4 to 5mini/5.

I also ran the tests and had Claude improve the prompts against them using GPT 5.