### PR TITLE
Improvements to create in APIv2

### DIFF
--- a/muckrock/foia/api_v2/serializers.py
+++ b/muckrock/foia/api_v2/serializers.py
@@ -411,3 +411,15 @@ class FOIACommunicationSerializer(serializers.ModelSerializer):
                 "help_text": "The list of files associated with this communication"
             },
         }
+
+
+class FOIARequestCreateResponseSerializer(serializers.Serializer):
+    """Documents the create endpoint's response body"""
+
+    status = serializers.CharField(help_text="Human-readable result message")
+    location = serializers.CharField(help_text="URL of the created composer")
+    requests = serializers.ListField(
+        child=serializers.IntegerField(),
+        required=False,
+        help_text="IDs of the created FOIA requests",
+    )

--- a/muckrock/foia/api_v2/serializers.py
+++ b/muckrock/foia/api_v2/serializers.py
@@ -73,14 +73,9 @@ class FOIARequestSerializer(serializers.ModelSerializer):
     )
 
     edited_boilerplate = serializers.BooleanField(
-        required=False,
-        default=False,
-        help_text=(
-            "If true, your `requested_docs` text is used directly as the full "
-            "request letter, bypassing the MuckRock template. "
-            "Template tags such as { name } and { closing } are still available "
-            "if you wish to use them."
-        ),
+        read_only=True,
+        source="composer.edited_boilerplate",
+        help_text="Whether the request bypassed the MuckRock template",
     )
 
     tags = serializers.StringRelatedField(
@@ -191,6 +186,7 @@ class FOIARequestCreateSerializer(serializers.ModelSerializer):
         queryset=Agency.objects.filter(status="approved"),
         many=True,
         required=True,
+        allow_empty=False,
         help_text="List of agency IDs of agencies you would like to send this request to.",
     )
     organization = serializers.PrimaryKeyRelatedField(
@@ -208,6 +204,15 @@ class FOIARequestCreateSerializer(serializers.ModelSerializer):
         help_text="List of tags to apply to this request",
     )
 
+    edited_boilerplate = serializers.BooleanField(
+        required=False,
+        default=False,
+        help_text=(
+            "If true, your requested_docs text is used directly as the full "
+            "request letter, bypassing the MuckRock template."
+        ),
+    )
+
     class Meta:
         """Filters for foia request create"""
 
@@ -218,6 +223,7 @@ class FOIARequestCreateSerializer(serializers.ModelSerializer):
             "embargo_status",
             "title",
             "requested_docs",
+            "edited_boilerplate",
             # "attachments",
             # "edit_collaborators",
             # "read_collaborators",
@@ -238,29 +244,34 @@ class FOIARequestCreateSerializer(serializers.ModelSerializer):
         super().__init__(*args, **kwargs)
 
         request = self.context.get("request", None)
-        view = self.context.get("view", None)
         user = request and request.user
         authed = user and user.is_authenticated
-        # are we currently generating the documentation
-        docs = getattr(view, "swagger_fake_view", False)
         if authed:
             # set the valid organizations to those the current user is a member of
             self.fields["organization"].queryset = Organization.objects.filter(
                 users=user
             )
-        # remove embargo fields if the user does not have permission to set them
-        if not docs and (not authed or not user.has_perm("foia.embargo_foiarequest")):
-            self.fields.pop("embargo_status")
 
     def validate_embargo_status(self, value):
-        """If the user doesn't have the permission to set to a permanent embargo, tell them"""
+        """Enforce embargo permissions, informing the user when they lack them"""
         request = self.context.get("request", None)
-        if value == "permanent" and not request.user.has_perm(
+        user = request and request.user
+
+        if value == "public":
+            return value
+
+        if not user or not user.has_perm("foia.embargo_foiarequest"):
+            raise serializers.ValidationError(
+                "You do not have permission to embargo requests."
+            )
+
+        if value == "permanent" and not user.has_perm(
             "foia.embargo_perm_foiarequest", self.instance
         ):
             raise serializers.ValidationError(
                 "You do not have permission to set embargo to permanent"
             )
+
         return value
 
 

--- a/muckrock/foia/api_v2/tests.py
+++ b/muckrock/foia/api_v2/tests.py
@@ -1,6 +1,5 @@
 # Django
-from django.contrib.auth.models import Permission
-from django.contrib.auth.models import User
+from django.contrib.auth.models import Permission, User
 from django.test import TestCase
 from django.urls import reverse
 
@@ -15,10 +14,7 @@ from muckrock.foia.factories import (
     FOIARequestFactory,
 )
 from muckrock.foia.models import FOIARequest
-from muckrock.organization.factories import (
-    MembershipFactory,
-    OrganizationFactory,
-)
+from muckrock.organization.factories import MembershipFactory, OrganizationFactory
 
 
 def _grant(user, codename):
@@ -141,11 +137,12 @@ class TestFOIARequestViewset(TestCase):
         )
         assert response.status_code == 402, response.json()
 
-    def test_create_foreign_organization_rejected(self):
-        """Filing under an org the user isn't in fails serializer validation (400)"""
+    def test_create_defaults_to_personal_org(self):
+        """Omitting organization files under the user's individual org"""
         agency = AgencyFactory.create()
         user = UserFactory.create()
-        other_org = OrganizationFactory.create()  # user is NOT a member
+        personal_org = user.profile.organization
+        _fund(personal_org)
         self.client.force_authenticate(user=user)
         response = self.client.post(
             reverse("api2-requests-list"),
@@ -153,14 +150,15 @@ class TestFOIARequestViewset(TestCase):
                 "agencies": [agency.pk],
                 "title": "Test",
                 "requested_docs": "Meeting minutes",
-                "organization": other_org.pk,
             },
+            format="json",
         )
-        assert response.status_code == 400, response.json()
-        assert "organization" in response.json()
+        assert response.status_code == 201, response.json()
+        foia = FOIARequest.objects.get(pk=response.json()["requests"][0])
+        assert foia.composer.organization == personal_org
 
-    def test_create_member_organization_allowed(self):
-        """Can file under an org the user IS a member of"""
+    def test_create_bills_the_named_organization(self):
+        """The composer is billed to the org the user selected, not their default"""
         agency = AgencyFactory.create()
         user = UserFactory.create()
         org = OrganizationFactory.create()
@@ -175,8 +173,53 @@ class TestFOIARequestViewset(TestCase):
                 "requested_docs": "Meeting minutes",
                 "organization": org.pk,
             },
+            format="json",
         )
         assert response.status_code == 201, response.json()
+        foia = FOIARequest.objects.get(pk=response.json()["requests"][0])
+        assert foia.composer.organization == org
+        # the named org was debited, not the user's personal org
+        org.refresh_from_db()
+        assert org.number_requests == 4
+
+    def test_create_nonexistent_organization_rejected(self):
+        """A nonexistent org PK fails validation (400)"""
+        agency = AgencyFactory.create()
+        user = UserFactory.create()
+        self.client.force_authenticate(user=user)
+        response = self.client.post(
+            reverse("api2-requests-list"),
+            {
+                "agencies": [agency.pk],
+                "title": "Test",
+                "requested_docs": "Meeting minutes",
+                "organization": 99999999,
+            },
+            format="json",
+        )
+        assert response.status_code == 400, response.json()
+        assert "organization" in response.json()
+
+    def test_create_personal_org_explicitly(self):
+        """A user can explicitly name their own individual org"""
+        agency = AgencyFactory.create()
+        user = UserFactory.create()
+        personal_org = user.profile.organization
+        _fund(personal_org)
+        self.client.force_authenticate(user=user)
+        response = self.client.post(
+            reverse("api2-requests-list"),
+            {
+                "agencies": [agency.pk],
+                "title": "Test",
+                "requested_docs": "Meeting minutes",
+                "organization": personal_org.pk,
+            },
+            format="json",
+        )
+        assert response.status_code == 201, response.json()
+        foia = FOIARequest.objects.get(pk=response.json()["requests"][0])
+        assert foia.composer.organization == personal_org
 
     def test_create_edited_boilerplate(self):
         """edited_boilerplate is settable on create and persists to the composer"""

--- a/muckrock/foia/api_v2/tests.py
+++ b/muckrock/foia/api_v2/tests.py
@@ -1,4 +1,6 @@
 # Django
+from django.contrib.auth.models import Permission
+from django.contrib.auth.models import User
 from django.test import TestCase
 from django.urls import reverse
 
@@ -12,6 +14,24 @@ from muckrock.foia.factories import (
     FOIAFileFactory,
     FOIARequestFactory,
 )
+from muckrock.foia.models import FOIARequest
+from muckrock.organization.factories import (
+    MembershipFactory,
+    OrganizationFactory,
+)
+
+
+def _grant(user, codename):
+    """Grant a permission and return the user with a fresh permission cache"""
+    user.user_permissions.add(Permission.objects.get(codename=codename))
+    return User.objects.get(pk=user.pk)
+
+
+def _fund(org, amount=5):
+    """Give an org a request balance so submit() succeeds"""
+    org.number_requests = amount
+    org.save()
+    return org
 
 
 class TestFOIARequestViewset(TestCase):
@@ -36,6 +56,7 @@ class TestFOIARequestViewset(TestCase):
     def test_create(self):
         agency = AgencyFactory.create()
         user = UserFactory.create()
+        _fund(user.profile.organization)
         self.client.force_authenticate(user=user)
         response = self.client.post(
             reverse("api2-requests-list"),
@@ -46,6 +67,241 @@ class TestFOIARequestViewset(TestCase):
             },
         )
         assert response.status_code == 201, response.json()
+
+    def test_create_missing_agencies(self):
+        """Omitting agencies returns 400 (previously a 500 KeyError)"""
+        user = UserFactory.create()
+        self.client.force_authenticate(user=user)
+        response = self.client.post(
+            reverse("api2-requests-list"),
+            {"title": "Test", "requested_docs": "Meeting minutes"},
+        )
+        assert response.status_code == 400, response.json()
+        assert "agencies" in response.json()
+
+    def test_create_empty_agencies(self):
+        """Empty agencies list returns 400"""
+        user = UserFactory.create()
+        self.client.force_authenticate(user=user)
+        response = self.client.post(
+            reverse("api2-requests-list"),
+            {"agencies": [], "title": "Test", "requested_docs": "Meeting minutes"},
+        )
+        assert response.status_code == 400, response.json()
+
+    def test_create_unapproved_agency(self):
+        """A non-approved agency is not in the serializer queryset, yielding 400"""
+        agency = AgencyFactory.create(status="pending")
+        user = UserFactory.create()
+        self.client.force_authenticate(user=user)
+        response = self.client.post(
+            reverse("api2-requests-list"),
+            {
+                "agencies": [agency.pk],
+                "title": "Test",
+                "requested_docs": "Meeting minutes",
+            },
+        )
+        assert response.status_code == 400, response.json()
+
+    def test_create_missing_title(self):
+        """Omitting title returns 400"""
+        agency = AgencyFactory.create()
+        user = UserFactory.create()
+        self.client.force_authenticate(user=user)
+        response = self.client.post(
+            reverse("api2-requests-list"),
+            {"agencies": [agency.pk], "requested_docs": "Meeting minutes"},
+        )
+        assert response.status_code == 400, response.json()
+
+    def test_create_missing_requested_docs(self):
+        """Omitting requested_docs returns 400"""
+        agency = AgencyFactory.create()
+        user = UserFactory.create()
+        self.client.force_authenticate(user=user)
+        response = self.client.post(
+            reverse("api2-requests-list"),
+            {"agencies": [agency.pk], "title": "Test"},
+        )
+        assert response.status_code == 400, response.json()
+
+    def test_create_insufficient_requests(self):
+        """Valid payload but no request balance returns 402, not 500"""
+        agency = AgencyFactory.create()
+        user = UserFactory.create()  # individual org, zero balance
+        self.client.force_authenticate(user=user)
+        response = self.client.post(
+            reverse("api2-requests-list"),
+            {
+                "agencies": [agency.pk],
+                "title": "Test",
+                "requested_docs": "Meeting minutes",
+            },
+        )
+        assert response.status_code == 402, response.json()
+
+    def test_create_foreign_organization_rejected(self):
+        """Filing under an org the user isn't in fails serializer validation (400)"""
+        agency = AgencyFactory.create()
+        user = UserFactory.create()
+        other_org = OrganizationFactory.create()  # user is NOT a member
+        self.client.force_authenticate(user=user)
+        response = self.client.post(
+            reverse("api2-requests-list"),
+            {
+                "agencies": [agency.pk],
+                "title": "Test",
+                "requested_docs": "Meeting minutes",
+                "organization": other_org.pk,
+            },
+        )
+        assert response.status_code == 400, response.json()
+        assert "organization" in response.json()
+
+    def test_create_member_organization_allowed(self):
+        """Can file under an org the user IS a member of"""
+        agency = AgencyFactory.create()
+        user = UserFactory.create()
+        org = OrganizationFactory.create()
+        MembershipFactory.create(user=user, organization=org)
+        _fund(org)
+        self.client.force_authenticate(user=user)
+        response = self.client.post(
+            reverse("api2-requests-list"),
+            {
+                "agencies": [agency.pk],
+                "title": "Test",
+                "requested_docs": "Meeting minutes",
+                "organization": org.pk,
+            },
+        )
+        assert response.status_code == 201, response.json()
+
+    def test_create_edited_boilerplate(self):
+        """edited_boilerplate is settable on create and persists to the composer"""
+        agency = AgencyFactory.create()
+        user = UserFactory.create()
+        _fund(user.profile.organization)
+        self.client.force_authenticate(user=user)
+        response = self.client.post(
+            reverse("api2-requests-list"),
+            {
+                "agencies": [agency.pk],
+                "title": "Test",
+                "requested_docs": "Meeting minutes",
+                "edited_boilerplate": True,
+            },
+        )
+        assert response.status_code == 201, response.json()
+        foia = FOIARequest.objects.get(pk=response.json()["requests"][0])
+        assert foia.composer.edited_boilerplate is True
+
+    def test_create_edited_boilerplate_defaults_false(self):
+        """Omitting edited_boilerplate defaults to False"""
+        agency = AgencyFactory.create()
+        user = UserFactory.create()
+        _fund(user.profile.organization)
+        self.client.force_authenticate(user=user)
+        response = self.client.post(
+            reverse("api2-requests-list"),
+            {
+                "agencies": [agency.pk],
+                "title": "Test",
+                "requested_docs": "Meeting minutes",
+            },
+        )
+        assert response.status_code == 201, response.json()
+        foia = FOIARequest.objects.get(pk=response.json()["requests"][0])
+        assert foia.composer.edited_boilerplate is False
+
+    def test_create_embargo_without_permission_rejected(self):
+        """Setting embargo without permission returns 400 with a message"""
+        agency = AgencyFactory.create()
+        user = UserFactory.create()
+        _fund(user.profile.organization)
+        self.client.force_authenticate(user=user)
+        response = self.client.post(
+            reverse("api2-requests-list"),
+            {
+                "agencies": [agency.pk],
+                "title": "Test",
+                "requested_docs": "Meeting minutes",
+                "embargo_status": "embargo",
+            },
+        )
+        assert response.status_code == 400, response.json()
+        assert "embargo_status" in response.json()
+
+    def test_create_embargo_with_permission(self):
+        """With embargo permission, embargo_status is honored"""
+        agency = AgencyFactory.create()
+        user = _grant(UserFactory.create(), "embargo_foiarequest")
+        _fund(user.profile.organization)
+        self.client.force_authenticate(user=user)
+        response = self.client.post(
+            reverse("api2-requests-list"),
+            {
+                "agencies": [agency.pk],
+                "title": "Test",
+                "requested_docs": "Meeting minutes",
+                "embargo_status": "embargo",
+            },
+        )
+        assert response.status_code == 201, response.json()
+        foia = FOIARequest.objects.get(pk=response.json()["requests"][0])
+        assert foia.composer.embargo_status == "embargo"
+
+    def test_create_public_needs_no_permission(self):
+        """Explicitly setting public requires no embargo permission"""
+        agency = AgencyFactory.create()
+        user = UserFactory.create()
+        _fund(user.profile.organization)
+        self.client.force_authenticate(user=user)
+        response = self.client.post(
+            reverse("api2-requests-list"),
+            {
+                "agencies": [agency.pk],
+                "title": "Test",
+                "requested_docs": "Meeting minutes",
+                "embargo_status": "public",
+            },
+        )
+        assert response.status_code == 201, response.json()
+
+    def test_create_permanent_embargo_without_permission(self):
+        """embargo perm but not perm-embargo perm: 'permanent' is rejected (400)"""
+        agency = AgencyFactory.create()
+        user = _grant(UserFactory.create(), "embargo_foiarequest")
+        _fund(user.profile.organization)
+        self.client.force_authenticate(user=user)
+        response = self.client.post(
+            reverse("api2-requests-list"),
+            {
+                "agencies": [agency.pk],
+                "title": "Test",
+                "requested_docs": "Meeting minutes",
+                "embargo_status": "permanent",
+            },
+        )
+        assert response.status_code == 400, response.json()
+
+    def test_create_invalid_embargo_status(self):
+        """A permitted user sending an invalid choice gets a 400"""
+        agency = AgencyFactory.create()
+        user = _grant(UserFactory.create(), "embargo_foiarequest")
+        _fund(user.profile.organization)
+        self.client.force_authenticate(user=user)
+        response = self.client.post(
+            reverse("api2-requests-list"),
+            {
+                "agencies": [agency.pk],
+                "title": "Test",
+                "requested_docs": "Meeting minutes",
+                "embargo_status": "not_a_real_value",
+            },
+        )
+        assert response.status_code == 400, response.json()
 
     def test_unauthenticated_cannot_list(self):
         response = self.client.get(reverse("api2-requests-list"))
@@ -60,7 +316,6 @@ class TestFOIARequestViewset(TestCase):
 
 
 class TestFOIACommunicationViewset(TestCase):
-
     def setUp(self):
         self.client = APIClient()
         self.user = UserFactory.create()

--- a/muckrock/foia/api_v2/viewsets.py
+++ b/muckrock/foia/api_v2/viewsets.py
@@ -8,6 +8,7 @@ from django.db import transaction
 # Third Party
 import django_filters
 from django_filters.rest_framework.backends import DjangoFilterBackend
+from drf_spectacular.utils import OpenApiResponse, extend_schema
 from rest_framework import filters, mixins, status as http_status, viewsets
 from rest_framework.response import Response
 
@@ -16,6 +17,7 @@ from muckrock.core.views import AuthenticatedAPIMixin
 from muckrock.foia.api_v2.serializers import (
     FOIACommunicationSerializer,
     FOIAFileSerializer,
+    FOIARequestCreateResponseSerializer,
     FOIARequestCreateSerializer,
     FOIARequestSerializer,
 )
@@ -53,6 +55,36 @@ class FOIARequestViewSet(
             )
         )
 
+    @extend_schema(
+        request=FOIARequestCreateSerializer,
+        responses={
+            201: OpenApiResponse(
+                response=FOIARequestCreateResponseSerializer,
+                description=(
+                    "Request submitted. Returns the composer location and the "
+                    "list of created FOIA request IDs."
+                ),
+            ),
+            400: OpenApiResponse(
+                description=(
+                    "Validation failed. Possible causes: no valid agencies "
+                    "provided, missing title or requested_docs, an organization "
+                    "you are not a member of, or an embargo status you lack "
+                    "permission to set."
+                ),
+            ),
+            401: OpenApiResponse(
+                description="Authentication credentials were not provided or are invalid.",
+            ),
+            402: OpenApiResponse(
+                response=FOIARequestCreateResponseSerializer,
+                description=(
+                    "The selected organization has no requests remaining. The "
+                    "request has been saved as a draft; its location is returned."
+                ),
+            ),
+        },
+    )
     def create(self, request, *args, **kwargs):
         """Submit a new request"""
         serializer = self.get_serializer(data=request.data)

--- a/muckrock/foia/api_v2/viewsets.py
+++ b/muckrock/foia/api_v2/viewsets.py
@@ -3,7 +3,7 @@ Viewsets for V2 of the FOIA API
 """
 
 # Django
-from django.template.defaultfilters import slugify
+from django.db import transaction
 
 # Third Party
 import django_filters
@@ -12,7 +12,6 @@ from rest_framework import filters, mixins, status as http_status, viewsets
 from rest_framework.response import Response
 
 # MuckRock
-from muckrock.agency.models.agency import Agency
 from muckrock.core.views import AuthenticatedAPIMixin
 from muckrock.foia.api_v2.serializers import (
     FOIACommunicationSerializer,
@@ -55,18 +54,23 @@ class FOIARequestViewSet(
         )
 
     def create(self, request, *args, **kwargs):
-        composer = FOIAComposer.objects.create(
-            user=request.user,
-            organization_id=request.data.get(
-                "organization", request.user.profile.organization.pk
-            ),
-            title=request.data["title"],
-            slug=slugify(request.data["title"]) or "untitled",
-            requested_docs=request.data["requested_docs"],
-            embargo_status=request.data.get("embargo_status", False),
-            edited_boilerplate=request.data.get("edited_boilerplate", False),
-        )
-        composer.agencies.set(Agency.objects.filter(pk__in=request.data["agencies"]))
+        """Submit a new request"""
+        serializer = self.get_serializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        data = serializer.validated_data
+
+        organization = data.get("organization") or request.user.profile.organization
+
+        with transaction.atomic():
+            composer = FOIAComposer.objects.create(
+                user=request.user,
+                organization=organization,
+                title=data["title"],
+                requested_docs=data["requested_docs"],
+                edited_boilerplate=data.get("edited_boilerplate", False),
+                embargo_status=data.get("embargo_status", "public"),
+            )
+            composer.agencies.set(data["agencies"])
 
         try:
             composer.submit()
@@ -80,7 +84,7 @@ class FOIARequestViewSet(
             )
         else:
             foias = list(composer.foias.all())
-            tags = request.data.get("tags", [])
+            tags = data.get("tags", [])
             if tags:
                 for foia in foias:
                     foia.tags.set(tags)


### PR DESCRIPTION
- Adds more tests
- Corrects the help text language for edit_boilerplate in the read serializer, adds the field to the create serializer so someone can create requests without using the boilerplate (requested by a user)
- Uses the serializer to validate fields
- Adds a FOIACreateResponseSerializer which we have DRF point to in order to show what actual responses look like in the auto-generated documentation
