### PR TITLE
Fix sharing

### DIFF
--- a/muckrock/foia/forms/detail.py
+++ b/muckrock/foia/forms/detail.py
@@ -120,12 +120,17 @@ class FOIAOwnerForm(forms.Form):
 
     def change_owner(self, user, foias):
         """Perform the owner change"""
-        foias = [f for f in foias if f.has_perm(user, "change")]
+        foias = [f for f in foias if f.composer.has_perm(user, "change")]
         new_user = self.cleaned_data["user"]
         for foia in foias:
             old_user = foia.composer.user
             foia.composer.user = new_user
             foia.composer.save()
+            # the new owner is now the creator; drop any redundant collaborator
+            # rows across every request on the composer so they aren't listed twice
+            for sibling in foia.composer.foias.all():
+                sibling.edit_collaborators.remove(new_user)
+                sibling.read_collaborators.remove(new_user)
             foia.notes.create(
                 author=user,
                 note=f"{user.username} ({user.pk}) changed ownership of this request "

--- a/muckrock/foia/forms/detail.py
+++ b/muckrock/foia/forms/detail.py
@@ -5,6 +5,7 @@ FOIA forms used on the detail page
 # Django
 from django import forms
 from django.contrib.auth.models import User
+from django.db import transaction
 
 # Standard Library
 from datetime import date, timedelta
@@ -118,6 +119,7 @@ class FOIAOwnerForm(forms.Form):
         super().__init__(*args, **kwargs)
         self.fields["user"].required = required
 
+    @transaction.atomic
     def change_owner(self, user, foias):
         """Perform the owner change"""
         foias = [f for f in foias if f.composer.has_perm(user, "change")]

--- a/muckrock/foia/tests/test_views.py
+++ b/muckrock/foia/tests/test_views.py
@@ -49,6 +49,7 @@ from muckrock.foia.views import (
     FollowingRequestList,
     MyRequestList,
     RequestList,
+    SharedRequestList,
     UpdateComposer,
     autosave,
     crowdfund_request,
@@ -364,6 +365,64 @@ class TestFollowingRequestList(TestCase):
         assert len(response.context_data["object_list"]) == 3
         for foia in (foias[0], foias[4], foias[6]):
             assert foia in response.context_data["object_list"]
+
+
+class TestSharedRequestList(TestCase):
+    """The shared-with-you list shows requests where the user is a collaborator."""
+
+    def setUp(self):
+        self.factory = RequestFactory()
+        self.user = UserFactory()
+        UserFactory(username="MuckrockStaff")
+
+    def _get_list(self, user):
+        request = self.factory.get(reverse("foia-list-shared"))
+        request.user = user
+        request = mock_middleware(request)
+        return SharedRequestList.as_view()(request)
+
+    def test_shows_edit_collaborations(self):
+        """Requests where the user is an editor should appear."""
+        foia = FOIARequestFactory()
+        foia.add_editor(self.user)
+        response = self._get_list(self.user)
+        assert foia in response.context_data["object_list"]
+
+    def test_shows_view_collaborations(self):
+        """Requests where the user is a viewer should appear."""
+        foia = FOIARequestFactory()
+        foia.add_viewer(self.user)
+        response = self._get_list(self.user)
+        assert foia in response.context_data["object_list"]
+
+    def test_excludes_owned_requests(self):
+        """Requests the user owns (but isn't a collaborator on) should NOT appear —
+        those belong under 'Yours', not 'Shared With You'."""
+        owned = FOIARequestFactory(composer__user=self.user)
+        response = self._get_list(self.user)
+        assert owned not in response.context_data["object_list"]
+
+    def test_excludes_unrelated_requests(self):
+        """Requests the user has no relationship to should not appear."""
+        other = FOIARequestFactory()
+        response = self._get_list(self.user)
+        assert other not in response.context_data["object_list"]
+
+    def test_excludes_others_collaborations(self):
+        """A request shared with someone else should not appear for this user."""
+        someone_else = UserFactory()
+        foia = FOIARequestFactory()
+        foia.add_editor(someone_else)
+        response = self._get_list(self.user)
+        assert foia not in response.context_data["object_list"]
+
+    def test_no_duplicate_rows(self):
+        """A request should appear once even if the join could fan out."""
+        foia = FOIARequestFactory()
+        foia.add_editor(self.user)
+        response = self._get_list(self.user)
+        object_list = list(response.context_data["object_list"])
+        assert object_list.count(foia) == 1
 
 
 class TestBulkActions(TestCase):

--- a/muckrock/foia/tests/test_views.py
+++ b/muckrock/foia/tests/test_views.py
@@ -40,6 +40,7 @@ from muckrock.foia.factories import (
     FOIARequestFactory,
     FOIATemplateFactory,
 )
+from muckrock.foia.forms import FOIAOwnerForm
 from muckrock.foia.models import FOIAComposer, FOIARequest
 from muckrock.foia.views import (
     ComposerDetail,
@@ -1069,6 +1070,34 @@ class TestRequestSharingViews(TestCase):
             idx=self.foia.id,
         )
         assert response.context_data["user_can_change_owner"] is True
+
+    def test_form_change_owner_rejects_non_owner(self):
+        """FOIAOwnerForm.change_owner must not transfer when called by an editor,
+        independent of any view-level guard."""
+        self.foia.add_editor(self.editor)
+        new_user = UserFactory()
+        form = FOIAOwnerForm({"user": new_user.pk})
+        assert form.is_valid()
+        form.change_owner(self.editor, [self.foia])
+        composer = FOIAComposer.objects.get(pk=self.foia.composer.pk)
+        assert (
+            composer.user == self.creator
+        ), "Editor calling the form method directly must not transfer ownership."
+
+    def test_change_owner_removes_new_owner_as_collaborator(self):
+        """Transferring to an existing editor must not leave them double-listed,
+        and must clear collaborator rows across all sibling requests."""
+        sibling = FOIARequestFactory(composer=self.foia.composer)
+        self.foia.add_editor(self.editor)
+        sibling.add_editor(self.editor)
+        _, composer = self._post_change_owner(self.creator, self.editor)
+        assert composer.user == self.editor
+        self.foia.refresh_from_db()
+        sibling.refresh_from_db()
+        assert not self.foia.has_editor(self.editor)
+        assert not sibling.has_editor(
+            self.editor
+        ), "New owner should be cleared as collaborator on sibling requests too."
 
 
 class TestFOIAComposerViews(TestCase):

--- a/muckrock/foia/tests/test_views.py
+++ b/muckrock/foia/tests/test_views.py
@@ -977,6 +977,99 @@ class TestRequestSharingViews(TestCase):
         assert response.status_code == 302
         assert not self.foia.has_viewer(a_viewer)
 
+    def _post_change_owner(self, actor, target):
+        """Helper: POST a change_owner action as `actor`, transferring to `target`."""
+        data = {"action": "change_owner", "user": target.pk}
+        request = self.factory.post(self.foia.get_absolute_url(), data)
+        request = mock_middleware(request)
+        request.user = actor
+        response = Detail.as_view()(
+            request,
+            jurisdiction=self.foia.jurisdiction.slug,
+            jidx=self.foia.jurisdiction.id,
+            slug=self.foia.slug,
+            idx=self.foia.id,
+        )
+        # re-read the composer from the DB; the FK isn't reflected by a plain
+        # refresh_from_db on the cached foia.composer
+        composer = FOIAComposer.objects.get(pk=self.foia.composer.pk)
+        return response, composer
+
+    def test_change_owner_editor_denied(self):
+        """Editors must not be able to change the owner of a request.
+
+        This is the core regression guard: `change_owner` authorizes on the
+        composer's `change` perm (is_owner_composer | is_staff), NOT the
+        request's `change` perm (which includes editors)."""
+        response, composer = self._post_change_owner(self.editor, self.editor)
+        assert response.status_code == 302
+        assert (
+            composer.user == self.creator
+        ), "An editor must not be able to seize ownership of the request."
+
+    def test_change_owner_viewer_denied(self):
+        """Viewers must not be able to change the owner."""
+        _, composer = self._post_change_owner(self.viewer, self.viewer)
+        assert composer.user == self.creator
+
+    def test_change_owner_normie_denied(self):
+        """Unrelated users must not be able to change the owner."""
+        _, composer = self._post_change_owner(self.normie, self.normie)
+        assert composer.user == self.creator
+
+    def test_change_owner_owner_allowed(self):
+        """The owner may transfer ownership (confirms we did not over-restrict)."""
+        new_owner = UserFactory()
+        response, composer = self._post_change_owner(self.creator, new_owner)
+        assert response.status_code == 302
+        assert composer.user == new_owner
+
+    def test_change_owner_staff_allowed(self):
+        """Staff may transfer ownership."""
+        new_owner = UserFactory()
+        _, composer = self._post_change_owner(self.staff, new_owner)
+        assert composer.user == new_owner
+
+    def test_change_owner_editor_denied_multirequest(self):
+        """An editor on one request of a multi-request composer must not be able
+        to seize the whole composer — the sibling requests must be untouched."""
+        sibling = FOIARequestFactory(composer=self.foia.composer)
+        assert self.foia.composer.foias.count() > 1
+        _, composer = self._post_change_owner(self.editor, self.editor)
+        assert composer.user == self.creator
+        sibling.refresh_from_db()
+        assert (
+            sibling.composer.user == self.creator
+        ), "Sibling requests sharing the composer must not change owner."
+
+    def test_change_owner_hidden_from_editor(self):
+        """The Change Owner control must not be offered to editors in context."""
+        request = self.factory.get(self.foia.get_absolute_url())
+        request = mock_middleware(request)
+        request.user = self.editor
+        response = Detail.as_view()(
+            request,
+            jurisdiction=self.foia.jurisdiction.slug,
+            jidx=self.foia.jurisdiction.id,
+            slug=self.foia.slug,
+            idx=self.foia.id,
+        )
+        assert response.context_data["user_can_change_owner"] is False
+
+    def test_change_owner_shown_to_owner(self):
+        """The owner should be offered the Change Owner control."""
+        request = self.factory.get(self.foia.get_absolute_url())
+        request = mock_middleware(request)
+        request.user = self.creator
+        response = Detail.as_view()(
+            request,
+            jurisdiction=self.foia.jurisdiction.slug,
+            jidx=self.foia.jurisdiction.id,
+            slug=self.foia.slug,
+            idx=self.foia.id,
+        )
+        assert response.context_data["user_can_change_owner"] is True
+
 
 class TestFOIAComposerViews(TestCase):
     """Tests for FOIA Composer views"""

--- a/muckrock/foia/urls.py
+++ b/muckrock/foia/urls.py
@@ -33,6 +33,11 @@ urlpatterns = [
         name="foia-list-following",
     ),
     re_path(
+        r"^list/shared/$",
+        views.SharedRequestList.as_view(),
+        name="foia-list-shared",
+    ),
+    re_path(
         r"^list/processing/$",
         views.ProcessingRequestList.as_view(),
         name="foia-list-processing",

--- a/muckrock/foia/views/detail.py
+++ b/muckrock/foia/views/detail.py
@@ -193,6 +193,9 @@ class Detail(DetailView):
         """Get context data about permissions"""
 
         context["user_can_edit"] = self.foia.has_perm(self.request.user, "change")
+        context["user_can_change_owner"] = self.foia.composer.has_perm(
+            self.request.user, "change"
+        )
         user_can_embargo = self.foia.has_perm(self.request.user, "embargo")
 
         context["user_can_pay"] = (

--- a/muckrock/foia/views/detail_actions.py
+++ b/muckrock/foia/views/detail_actions.py
@@ -511,7 +511,7 @@ def promote(request, foia):
 def change_owner(request, foia):
     """Change the owner of the request"""
     form = FOIAOwnerForm(request.POST)
-    has_perm = foia.has_perm(request.user, "change")
+    has_perm = foia.composer.has_perm(request.user, "change")
     if not has_perm or not form.is_valid():
         return _get_redirect(request, foia)
 

--- a/muckrock/foia/views/list.py
+++ b/muckrock/foia/views/list.py
@@ -7,7 +7,7 @@ from django.contrib import messages
 from django.contrib.auth.decorators import login_required, user_passes_test
 from django.contrib.auth.mixins import UserPassesTestMixin
 from django.db import transaction
-from django.db.models import Count, Prefetch
+from django.db.models import Count, Prefetch, Q
 from django.http import Http404
 from django.shortcuts import redirect
 from django.urls import reverse
@@ -572,6 +572,21 @@ class FollowingRequestList(RequestList):
             f.pk for f in following(self.request.user, FOIARequest) if f is not None
         ]
         return queryset.filter(pk__in=followed)
+
+
+@class_view_decorator(login_required)
+class SharedRequestList(RequestList):
+    """List of FOIA requests explicitly shared with the current user"""
+
+    title = "Shared With You"
+
+    def get_queryset(self):
+        """Limit to requests where the user is an edit or view collaborator"""
+        queryset = super().get_queryset()
+        return queryset.filter(
+            Q(edit_collaborators=self.request.user)
+            | Q(read_collaborators=self.request.user)
+        ).distinct()
 
 
 class BaseProcessingRequestList(RequestList):

--- a/muckrock/foia/views/list.py
+++ b/muckrock/foia/views/list.py
@@ -578,7 +578,7 @@ class FollowingRequestList(RequestList):
 class SharedRequestList(RequestList):
     """List of FOIA requests explicitly shared with the current user"""
 
-    title = "Shared With You"
+    title = "Shared with You"
 
     def get_queryset(self):
         """Limit to requests where the user is an edit or view collaborator"""

--- a/muckrock/templates/foia/detail/access.html
+++ b/muckrock/templates/foia/detail/access.html
@@ -109,41 +109,41 @@
 
       </tbody>
     </table>
-
-    <form class="change-owner" method="post">
-      {% csrf_token %}
-      <h3>Change Owner</h3>
-      <p class="help-text error">
-        Warning: This will give control of this request to another user.  You
-        will lose access to this request.  Please be sure you are selecting the
-        correct user.
-      </p>
-      {% if siblings|length > 1 %}
-      <p class="help-text error">
-        The following requests were filed with this request, and will also have
-        their owner changed:
-        <ul>
-          {% for sibling in siblings %}
-            {% if sibling != foia %}
-              <li><a href="{{ sibling.get_absolute_url }}">{{ sibling.title }}</a>
-            {% endif %}
-          {% endfor %}
-        </ul>
-      </p>
-      {% endif %}
-      <div class="picker">
-        <div class="user search input">
-          <label for="{{ owner_form.user.id_for_label}}">
-            Search for MuckRock users
-          </label>
-          {{ owner_form.user }}
+    {% if user_can_change_owner %}
+      <form class="change-owner" method="post">
+        {% csrf_token %}
+        <h3>Change Owner</h3>
+        <p class="help-text error">
+          Warning: This will give control of this request to another user.  You
+          will lose access to this request.  Please be sure you are selecting the
+          correct user.
+        </p>
+        {% if siblings|length > 1 %}
+        <p class="help-text error">
+          The following requests were filed with this request, and will also have
+          their owner changed:
+          <ul>
+            {% for sibling in siblings %}
+              {% if sibling != foia %}
+                <li><a href="{{ sibling.get_absolute_url }}">{{ sibling.title }}</a>
+              {% endif %}
+            {% endfor %}
+          </ul>
+        </p>
+        {% endif %}
+        <div class="picker">
+          <div class="user search input">
+            <label for="{{ owner_form.user.id_for_label}}">
+              Search for MuckRock users
+            </label>
+            {{ owner_form.user }}
+          </div>
         </div>
-      </div>
-      <button class="failure button" type="submit" name="action" value="change_owner">
-        Change Owner
-      </button>
-    </form>
-
+        <button class="failure button" type="submit" name="action" value="change_owner">
+          Change Owner
+        </button>
+      </form>
+    {% endif %}
   </section>
 
 {% endif %}

--- a/muckrock/templates/foia/list.html
+++ b/muckrock/templates/foia/list.html
@@ -22,7 +22,7 @@
         <li class="{% active request '^/foi/proxy-list/$' %}"><a href="{% url 'foia-proxy-list' %}">Proxy</a></li>
       {% endif %}
       <li class="{% active request '^/foi/list/following/$' %}"><a href="{% url 'foia-list-following' %}">Following</a></li>
-      <li class="{% active request '^/foi/list/shared/$' %}"><a href="{% url 'foia-list-shared' %}">Shared With You</a></li>
+      <li class="{% active request '^/foi/list/shared/$' %}"><a href="{% url 'foia-list-shared' %}">Shared with You</a></li>
       {% if user.is_staff %}
         <li class="{% active request '^/foi/list/processing/$' %}"><a href="{% url 'foia-list-processing' %}">Processing</a></li>
         <li class="{% active request '^/foi/list/processing-portal/$' %}"><a href="{% url 'foia-list-processing-portal' %}">Portal</a></li>

--- a/muckrock/templates/foia/list.html
+++ b/muckrock/templates/foia/list.html
@@ -22,6 +22,7 @@
         <li class="{% active request '^/foi/proxy-list/$' %}"><a href="{% url 'foia-proxy-list' %}">Proxy</a></li>
       {% endif %}
       <li class="{% active request '^/foi/list/following/$' %}"><a href="{% url 'foia-list-following' %}">Following</a></li>
+      <li class="{% active request '^/foi/list/shared/$' %}"><a href="{% url 'foia-list-shared' %}">Shared With You</a></li>
       {% if user.is_staff %}
         <li class="{% active request '^/foi/list/processing/$' %}"><a href="{% url 'foia-list-processing' %}">Processing</a></li>
         <li class="{% active request '^/foi/list/processing-portal/$' %}"><a href="{% url 'foia-list-processing-portal' %}">Portal</a></li>


### PR DESCRIPTION
- Ensures editors can't see the Change Owner section of the "Sharing" tab. 
- Ensures editors and viewers can't transfer the composer at the view and form level. 
- While testing this, I noticed there was no straightforward way to show what requests were shared with you, so I added the ability to see requests shared with you. 
- While I was there, I noticed that you could transfer ownership to someone who was already an editor or viewer and it would mean that user was listed twice in the list of who has access. Now, if someone gets made an owner of a composer (and their attached requests), it removes them as an editor or viewer since it makes no sense for them to be both and creates a confusing UI experience. 
- Adds tests for the permissions as well as the new shared request list


