### PR TITLE
Fix multirequest rejection stock response text population 

### DIFF
--- a/compose/local/django/Dockerfile
+++ b/compose/local/django/Dockerfile
@@ -40,7 +40,7 @@ ENV SODIUM_INSTALL=system
 
 # install NVM
 ENV NVM_DIR /usr/local/nvm
-ENV NODE_VERSION 18.16.0
+ENV NODE_VERSION 22.12.0
 
 RUN mkdir $NVM_DIR
 RUN curl https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.3/install.sh | bash \

--- a/muckrock/assets/js/foiaRequest.js
+++ b/muckrock/assets/js/foiaRequest.js
@@ -554,8 +554,8 @@ $("#id_contact-stock_response").change(function() {
 $("#id_stock_response").change(function() {
   $("#id_note").val($(this).val());
 });
-$(".multirequest [name='stock_response']").change(function() {
-  $(this).siblings("textarea").val($(this).val());
+$(".multi-reject-form [name='stock_response']").change(function() {
+    $(this).closest(".multi-reject-form").find("textarea").val($(this).val());
 });
 $(".new-agency [name$='stock_response']").change(function() {
   $(this).siblings("textarea").val($(this).val());


### PR DESCRIPTION
- Fixes the selector for multirequest rejection text area so that stock responses populate the text area with the desired text. 
- Updates Node in the docker container because otherwise I wasn't able to rebuild
- Should close #2238 and #2198

<img width="1917" height="891" alt="BEFORE  MultiRequest stock responses not populating text area on staging" src="https://github.com/user-attachments/assets/e849f7d3-97df-4ea1-86ff-97034e1f47b2" />

<img width="1917" height="891" alt="AFTER  Multirequest stock responses populating text in deploy preview" src="https://github.com/user-attachments/assets/6094e9ab-3d0a-4768-8796-7449c69306b4" />
