### PR TITLE
Show and edit internal notes on the frontend

### DIFF
--- a/muckrock/accounts/forms.py
+++ b/muckrock/accounts/forms.py
@@ -9,7 +9,7 @@ from django import forms
 import logging
 
 # MuckRock
-from muckrock.accounts.models import Profile
+from muckrock.accounts.models import InternalNote, Profile
 from muckrock.organization.forms import StripeForm
 
 logger = logging.getLogger(__name__)
@@ -52,3 +52,12 @@ class ContactForm(forms.Form):
 
     subject = forms.CharField(max_length=255)
     message = forms.CharField(widget=forms.Textarea)
+
+
+class InternalNoteForm(forms.ModelForm):
+    """A form for staff to write private notes about a user"""
+
+    class Meta:
+        model = InternalNote
+        fields = ["text", "category", "warning_level"]
+        widgets = {"text": forms.Textarea(attrs={"rows": 4})}

--- a/muckrock/accounts/forms.py
+++ b/muckrock/accounts/forms.py
@@ -61,3 +61,4 @@ class InternalNoteForm(forms.ModelForm):
         model = InternalNote
         fields = ["text", "category", "warning_level"]
         widgets = {"text": forms.Textarea(attrs={"rows": 4})}
+        help_texts = {"text": "Markdown is supported"}

--- a/muckrock/accounts/templatetags/account_tags.py
+++ b/muckrock/accounts/templatetags/account_tags.py
@@ -1,0 +1,43 @@
+"""
+Template tags for the accounts application
+"""
+
+# Django
+from django import template
+
+# MuckRock
+from muckrock.accounts.forms import InternalNoteForm
+from muckrock.accounts.utils import can_see_internal_notes, note_form_prefix
+
+register = template.Library()
+
+
+@register.inclusion_tag("accounts/internal_notes.html", takes_context=True)
+def internal_notes(context, user_obj):
+    """Show and edit the private staff notes about a user
+
+    Renders nothing at all for anybody who may not see internal notes.
+    """
+    request = context.get("request")
+    if request is None or user_obj is None:
+        return {"show_notes": False}
+    if not can_see_internal_notes(request.user):
+        return {"show_notes": False}
+
+    notes = [
+        {
+            "note": note,
+            "form": InternalNoteForm(instance=note, prefix=note_form_prefix(note=note)),
+        }
+        for note in user_obj.internal_notes.select_related("by__profile", "category")
+    ]
+    return {
+        "show_notes": True,
+        # the inclusion tag gets a fresh context, so pass along what the
+        # forms in the template need
+        "csrf_token": context.get("csrf_token"),
+        "notes_user": user_obj,
+        "notes": notes,
+        "note_form": InternalNoteForm(prefix=note_form_prefix(user=user_obj)),
+        "next": request.get_full_path(),
+    }

--- a/muckrock/accounts/tests/test_internal_notes.py
+++ b/muckrock/accounts/tests/test_internal_notes.py
@@ -13,6 +13,7 @@ from muckrock.accounts.models import InternalNote
 from muckrock.accounts.utils import note_form_prefix
 from muckrock.core.factories import UserFactory
 from muckrock.foia.factories import FOIAComposerFactory, FOIARequestFactory
+from muckrock.task.factories import FlaggedTaskFactory
 from muckrock.task.models import MultiRequestTask
 
 NOTE_TEXT = "This user keeps filing the same request over and over"
@@ -145,6 +146,22 @@ class TestMultiRequestTaskNotes(InternalNoteTestCase):
         self.client.force_login(self.user)
         response = self.client.get(self.url)
         assert response.status_code == 302
+
+    def test_task_notes_are_named_apart_from_internal_notes(self):
+        """Notes about the request are labeled separately from notes about
+        the user, since both forms are on this page"""
+        self.client.force_login(self.staff)
+        response = self.client.get(self.url)
+        self.assertContains(response, "Task Notes")
+        self.assertContains(response, "Internal Notes")
+
+    def test_other_tasks_still_say_note(self):
+        """Only the multirequest page renames the shared note form"""
+        self.client.force_login(self.staff)
+        flagged = FlaggedTaskFactory()
+        response = self.client.get(reverse("flagged-task", kwargs={"pk": flagged.pk}))
+        self.assertContains(response, ">Note</p>")
+        self.assertNotContains(response, "Task Notes")
 
 
 class TestCreateNote(InternalNoteTestCase):

--- a/muckrock/accounts/tests/test_internal_notes.py
+++ b/muckrock/accounts/tests/test_internal_notes.py
@@ -62,6 +62,23 @@ class TestProfileNotes(InternalNoteTestCase):
             response, reverse("acct-note-create", kwargs={"idx": self.user.pk})
         )
 
+    def test_note_text_is_markdown(self):
+        """Notes are written in markdown"""
+        self.note.text = "Filed **too many** requests, see [the log](/foia/)"
+        self.note.save()
+        self.client.force_login(self.staff)
+        response = self.client.get(self.url)
+        self.assertContains(response, "<strong>too many</strong>")
+        self.assertContains(response, '<a href="/foia/">the log</a>')
+
+    def test_note_markdown_is_sanitized(self):
+        """Markdown does not let a note smuggle in a script tag"""
+        self.note.text = "Suspicious <script>alert('xss')</script>"
+        self.note.save()
+        self.client.force_login(self.staff)
+        response = self.client.get(self.url)
+        self.assertNotContains(response, "<script>alert")
+
     def test_owner_does_not_see_notes(self):
         """The user a note is about may never see it"""
         self.client.force_login(self.user)

--- a/muckrock/accounts/tests/test_internal_notes.py
+++ b/muckrock/accounts/tests/test_internal_notes.py
@@ -1,0 +1,290 @@
+"""
+Tests for internal staff notes about users
+
+Internal notes must never be visible to non-staff users.
+"""
+
+# Django
+from django.test import TestCase
+from django.urls import reverse
+
+# MuckRock
+from muckrock.accounts.models import InternalNote
+from muckrock.accounts.utils import note_form_prefix
+from muckrock.core.factories import UserFactory
+from muckrock.foia.factories import FOIAComposerFactory, FOIARequestFactory
+from muckrock.task.models import MultiRequestTask
+
+NOTE_TEXT = "This user keeps filing the same request over and over"
+
+
+class InternalNoteTestCase(TestCase):
+    """Common set up - a user with a note about them, written by staff"""
+
+    def setUp(self):
+        self.staff = UserFactory(is_staff=True)
+        self.user = UserFactory()
+        self.note = InternalNote.objects.create(
+            user=self.user, by=self.staff, text=NOTE_TEXT
+        )
+
+    def add_data(self, user, **kwargs):
+        """Post data for the add note form, with its form prefix"""
+        prefix = note_form_prefix(user=user)
+        data = {"text": NOTE_TEXT, **kwargs}
+        return {"{}-{}".format(prefix, key): value for key, value in data.items()}
+
+    def edit_data(self, note, **kwargs):
+        """Post data for a note's edit form, with its form prefix"""
+        prefix = note_form_prefix(note=note)
+        data = {"text": NOTE_TEXT, **kwargs}
+        return {"{}-{}".format(prefix, key): value for key, value in data.items()}
+
+
+class TestProfileNotes(InternalNoteTestCase):
+    """Notes show up on a user's profile page, for staff only"""
+
+    def setUp(self):
+        super().setUp()
+        # a submitted composer makes the profile page publicly viewable
+        FOIAComposerFactory(user=self.user, status="submitted")
+        self.url = reverse("acct-profile", kwargs={"username": self.user.username})
+
+    def test_staff_sees_notes(self):
+        """Staff see the notes and the form to add more"""
+        self.client.force_login(self.staff)
+        response = self.client.get(self.url)
+        assert response.status_code == 200
+        self.assertContains(response, "Internal Notes")
+        self.assertContains(response, NOTE_TEXT)
+        self.assertContains(
+            response, reverse("acct-note-create", kwargs={"idx": self.user.pk})
+        )
+
+    def test_owner_does_not_see_notes(self):
+        """The user a note is about may never see it"""
+        self.client.force_login(self.user)
+        response = self.client.get(self.url)
+        assert response.status_code == 200
+        self.assertNotContains(response, "Internal Notes")
+        self.assertNotContains(response, NOTE_TEXT)
+
+    def test_other_user_does_not_see_notes(self):
+        """Other logged in users may not see notes"""
+        self.client.force_login(UserFactory())
+        response = self.client.get(self.url)
+        assert response.status_code == 200
+        self.assertNotContains(response, "Internal Notes")
+        self.assertNotContains(response, NOTE_TEXT)
+
+    def test_anonymous_does_not_see_notes(self):
+        """Logged out users may not see notes"""
+        response = self.client.get(self.url)
+        assert response.status_code == 200
+        self.assertNotContains(response, "Internal Notes")
+        self.assertNotContains(response, NOTE_TEXT)
+
+
+class TestComposerNotes(InternalNoteTestCase):
+    """Notes about the filer show up on a multirequest page, for staff only"""
+
+    def setUp(self):
+        super().setUp()
+        self.composer = FOIAComposerFactory(user=self.user, status="filed")
+        # the detail page redirects to the request itself if there is only one
+        FOIARequestFactory(composer=self.composer)
+        FOIARequestFactory(composer=self.composer)
+        self.url = reverse(
+            "foia-composer-detail",
+            kwargs={"slug": self.composer.slug, "idx": self.composer.pk},
+        )
+
+    def test_staff_sees_notes(self):
+        """Staff see notes about the user who filed the multirequest"""
+        self.client.force_login(self.staff)
+        response = self.client.get(self.url)
+        assert response.status_code == 200
+        self.assertContains(response, "Internal Notes")
+        self.assertContains(response, NOTE_TEXT)
+
+    def test_owner_does_not_see_notes(self):
+        """The filer may not see notes about themselves"""
+        self.client.force_login(self.user)
+        response = self.client.get(self.url)
+        assert response.status_code == 200
+        self.assertNotContains(response, "Internal Notes")
+        self.assertNotContains(response, NOTE_TEXT)
+
+    def test_anonymous_does_not_see_notes(self):
+        """Logged out users may not see notes"""
+        response = self.client.get(self.url)
+        assert response.status_code == 200
+        self.assertNotContains(response, "Internal Notes")
+        self.assertNotContains(response, NOTE_TEXT)
+
+
+class TestMultiRequestTaskNotes(InternalNoteTestCase):
+    """Notes show up on the multirequest task page, which is staff only"""
+
+    def setUp(self):
+        super().setUp()
+        self.composer = FOIAComposerFactory(user=self.user, status="submitted")
+        self.task = MultiRequestTask.objects.create(composer=self.composer)
+        self.url = reverse("multirequest-task", kwargs={"pk": self.task.pk})
+
+    def test_staff_sees_notes(self):
+        """Staff see notes about the user who filed the multirequest"""
+        self.client.force_login(self.staff)
+        response = self.client.get(self.url)
+        assert response.status_code == 200
+        self.assertContains(response, "Internal Notes")
+        self.assertContains(response, NOTE_TEXT)
+
+    def test_non_staff_cannot_view_the_page(self):
+        """The task page itself is staff only"""
+        self.client.force_login(self.user)
+        response = self.client.get(self.url)
+        assert response.status_code == 302
+
+
+class TestCreateNote(InternalNoteTestCase):
+    """Only staff may write notes"""
+
+    def setUp(self):
+        super().setUp()
+        self.url = reverse("acct-note-create", kwargs={"idx": self.user.pk})
+        self.profile_url = reverse(
+            "acct-profile", kwargs={"username": self.user.username}
+        )
+
+    def test_staff_creates_note(self):
+        """A staff member's note is credited to them"""
+        self.client.force_login(self.staff)
+        response = self.client.post(
+            self.url, self.add_data(self.user, text="A brand new note")
+        )
+        assert response.status_code == 302
+        assert response.url == self.profile_url
+        note = self.user.internal_notes.latest()
+        assert note.text == "A brand new note"
+        assert note.by == self.staff
+
+    def test_returns_to_the_page_it_came_from(self):
+        """Notes can be written from several pages"""
+        self.client.force_login(self.staff)
+        data = self.add_data(self.user)
+        data["next"] = "/task/multirequest/"
+        response = self.client.post(self.url, data)
+        assert response.status_code == 302
+        assert response.url == "/task/multirequest/"
+
+    def test_ignores_offsite_redirects(self):
+        """An offsite next falls back to the user's profile"""
+        self.client.force_login(self.staff)
+        data = self.add_data(self.user)
+        data["next"] = "https://example.com/"
+        response = self.client.post(self.url, data)
+        assert response.status_code == 302
+        assert response.url == self.profile_url
+
+    def test_empty_note_is_not_saved(self):
+        """The text of a note is required"""
+        self.client.force_login(self.staff)
+        response = self.client.post(self.url, self.add_data(self.user, text=""))
+        assert response.status_code == 302
+        assert self.user.internal_notes.count() == 1
+
+    def test_non_staff_cannot_create_note(self):
+        """Non-staff users may not write notes"""
+        self.client.force_login(self.user)
+        response = self.client.post(self.url, self.add_data(self.user))
+        assert response.status_code == 302
+        assert response.url != self.profile_url
+        assert self.user.internal_notes.count() == 1
+
+    def test_anonymous_cannot_create_note(self):
+        """Logged out users may not write notes"""
+        response = self.client.post(self.url, self.add_data(self.user))
+        assert response.status_code == 302
+        assert self.user.internal_notes.count() == 1
+
+    def test_get_not_allowed(self):
+        """Notes are only written by posting"""
+        self.client.force_login(self.staff)
+        response = self.client.get(self.url)
+        assert response.status_code == 405
+
+
+class TestUpdateNote(InternalNoteTestCase):
+    """Only staff may edit notes"""
+
+    def setUp(self):
+        super().setUp()
+        self.url = reverse("acct-note-update", kwargs={"idx": self.note.pk})
+
+    def test_staff_updates_note(self):
+        """Staff can edit a note, including notes they did not write"""
+        other_staff = UserFactory(is_staff=True)
+        self.client.force_login(other_staff)
+        response = self.client.post(
+            self.url, self.edit_data(self.note, text="Updated text")
+        )
+        assert response.status_code == 302
+        self.note.refresh_from_db()
+        assert self.note.text == "Updated text"
+        # the original author is preserved
+        assert self.note.by == self.staff
+
+    def test_staff_sets_warning_level(self):
+        """Staff can escalate a note's warning level"""
+        self.client.force_login(self.staff)
+        self.client.post(self.url, self.edit_data(self.note, warning_level="final"))
+        self.note.refresh_from_db()
+        assert self.note.warning_level == "final"
+
+    def test_non_staff_cannot_update_note(self):
+        """Non-staff users may not edit notes"""
+        self.client.force_login(self.user)
+        response = self.client.post(
+            self.url, self.edit_data(self.note, text="Nothing to see here")
+        )
+        assert response.status_code == 302
+        self.note.refresh_from_db()
+        assert self.note.text == NOTE_TEXT
+
+    def test_anonymous_cannot_update_note(self):
+        """Logged out users may not edit notes"""
+        response = self.client.post(
+            self.url, self.edit_data(self.note, text="Nothing to see here")
+        )
+        assert response.status_code == 302
+        self.note.refresh_from_db()
+        assert self.note.text == NOTE_TEXT
+
+
+class TestDeleteNote(InternalNoteTestCase):
+    """Only staff may delete notes"""
+
+    def setUp(self):
+        super().setUp()
+        self.url = reverse("acct-note-delete", kwargs={"idx": self.note.pk})
+
+    def test_staff_deletes_note(self):
+        """Staff can delete a note"""
+        self.client.force_login(self.staff)
+        response = self.client.post(self.url)
+        assert response.status_code == 302
+        assert not InternalNote.objects.filter(pk=self.note.pk).exists()
+
+    def test_non_staff_cannot_delete_note(self):
+        """Non-staff users may not delete notes"""
+        self.client.force_login(self.user)
+        response = self.client.post(self.url)
+        assert response.status_code == 302
+        assert InternalNote.objects.filter(pk=self.note.pk).exists()
+
+    def test_anonymous_cannot_delete_note(self):
+        """Logged out users may not delete notes"""
+        response = self.client.post(self.url)
+        assert response.status_code == 302
+        assert InternalNote.objects.filter(pk=self.note.pk).exists()

--- a/muckrock/accounts/urls.py
+++ b/muckrock/accounts/urls.py
@@ -52,6 +52,21 @@ urlpatterns = [
         r"^contact_user/(?P<idx>\d+)/$", views.contact_user, name="acct-contact-user"
     ),
     re_path(
+        r"^notes/user/(?P<idx>\d+)/$",
+        views.create_internal_note,
+        name="acct-note-create",
+    ),
+    re_path(
+        r"^notes/(?P<idx>\d+)/edit/$",
+        views.update_internal_note,
+        name="acct-note-update",
+    ),
+    re_path(
+        r"^notes/(?P<idx>\d+)/delete/$",
+        views.delete_internal_note,
+        name="acct-note-delete",
+    ),
+    re_path(
         r"^notifications/$", views.NotificationList.as_view(), name="acct-notifications"
     ),
     re_path(

--- a/muckrock/accounts/utils.py
+++ b/muckrock/accounts/utils.py
@@ -30,6 +30,26 @@ from muckrock.core.utils import retry_on_error, stripe_retry_on_error
 logger = logging.getLogger(__name__)
 
 
+def can_see_internal_notes(user):
+    """Internal notes are private staff records about a user
+
+    They must never be exposed to non-staff users.  This is the single place
+    where that is decided, so additional requirements can be added later.
+    """
+    return user.is_authenticated and user.is_staff
+
+
+def note_form_prefix(note=None, user=None):
+    """Namespace an internal note form
+
+    Several of these forms are rendered on the same page, so each one needs its
+    own prefix to keep field ids from colliding.
+    """
+    if note is not None:
+        return "note-{}".format(note.pk)
+    return "add-note-{}".format(user.pk)
+
+
 def unique_username(name):
     """Create a globally unique username from a name and return it."""
     # username can be at most 150 characters

--- a/muckrock/accounts/views.py
+++ b/muckrock/accounts/views.py
@@ -19,8 +19,10 @@ from django.http.response import (
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
 from django.utils.decorators import method_decorator
+from django.utils.http import url_has_allowed_host_and_scheme
 from django.views.decorators.clickjacking import xframe_options_exempt
 from django.views.decorators.csrf import csrf_exempt
+from django.views.decorators.http import require_POST
 from django.views.generic import FormView, ListView, RedirectView, TemplateView
 
 # Standard Library
@@ -40,11 +42,16 @@ from muckrock.accounts.forms import (
     BuyRequestForm,
     ContactForm,
     EmailSettingsForm,
+    InternalNoteForm,
     OrgPreferencesForm,
 )
 from muckrock.accounts.mixins import BuyRequestsMixin
-from muckrock.accounts.models import Notification, RecurringDonation
-from muckrock.accounts.utils import mixpanel_event
+from muckrock.accounts.models import InternalNote, Notification, RecurringDonation
+from muckrock.accounts.utils import (
+    can_see_internal_notes,
+    mixpanel_event,
+    note_form_prefix,
+)
 from muckrock.agency.models import Agency
 from muckrock.core.views import MRAutocompleteView, MRFilterListView
 from muckrock.crowdfund.models import RecurringCrowdfundPayment
@@ -280,6 +287,58 @@ def contact_user(request, idx):
         else:
             messages.error(request, "Message failed!")
     return redirect(user)
+
+
+def _note_redirect(request, user):
+    """Send the staffer back to the page they wrote the note from"""
+    url = request.POST.get("next")
+    if url and url_has_allowed_host_and_scheme(url, allowed_hosts=None):
+        return redirect(url)
+    return redirect(user)
+
+
+@require_POST
+@user_passes_test(can_see_internal_notes)
+def create_internal_note(request, idx):
+    """Let staff write a private note about a user"""
+    user = get_object_or_404(User, pk=idx)
+    form = InternalNoteForm(request.POST, prefix=note_form_prefix(user=user))
+    if form.is_valid():
+        note = form.save(commit=False)
+        note.user = user
+        note.by = request.user
+        note.save()
+        messages.success(request, "Note added")
+    else:
+        messages.error(request, "Note not added: %s" % form.errors.as_text())
+    return _note_redirect(request, user)
+
+
+@require_POST
+@user_passes_test(can_see_internal_notes)
+def update_internal_note(request, idx):
+    """Let staff edit a private note about a user"""
+    note = get_object_or_404(InternalNote, pk=idx)
+    form = InternalNoteForm(
+        request.POST, instance=note, prefix=note_form_prefix(note=note)
+    )
+    if form.is_valid():
+        form.save()
+        messages.success(request, "Note updated")
+    else:
+        messages.error(request, "Note not updated: %s" % form.errors.as_text())
+    return _note_redirect(request, note.user)
+
+
+@require_POST
+@user_passes_test(can_see_internal_notes)
+def delete_internal_note(request, idx):
+    """Let staff delete a private note about a user"""
+    note = get_object_or_404(InternalNote, pk=idx)
+    user = note.user
+    note.delete()
+    messages.success(request, "Note deleted")
+    return _note_redirect(request, user)
 
 
 @csrf_exempt

--- a/muckrock/assets/scss/pattern/_internal-notes.scss
+++ b/muckrock/assets/scss/pattern/_internal-notes.scss
@@ -1,0 +1,95 @@
+// Private staff notes about a user
+// Shown on profile, composer detail and multirequest task pages
+
+.internal-notes {
+    margin: $vr 0;
+    padding: $vr/2 $vr;
+    border-left: 4px solid $color-red;
+    background-color: $color-grey-8;
+
+    h3 small {
+        display: block;
+        color: $color-grey-3;
+        font-weight: normal;
+    }
+
+    .internal-notes__list {
+        margin: 0;
+        padding: 0;
+    }
+
+    .internal-notes__empty {
+        color: $color-grey-3;
+    }
+
+    // set the add form apart from the last note's Edit button
+    .internal-notes__add {
+        margin-top: $vr;
+        border-top: 1px solid $color-grey-7;
+        padding-top: $vr/2;
+
+        // the button closes the form again, so it says so while it is open
+        .internal-notes__label-open {
+            display: none;
+        }
+
+        &[open] {
+            .internal-notes__label-closed {
+                display: none;
+            }
+
+            .internal-notes__label-open {
+                display: inline;
+            }
+        }
+    }
+
+    .internal-note {
+        padding: $vr/2 0;
+        border-bottom: 1px solid $color-grey-7;
+
+        &:last-child {
+            border-bottom: none;
+        }
+    }
+
+    .internal-note__meta {
+        margin-bottom: $vr/4;
+        color: $color-grey-3;
+        font-size: .875em;
+
+        > * {
+            margin-right: $vr/2;
+        }
+    }
+
+    .internal-note__by {
+        font-weight: bold;
+        color: $color-black;
+    }
+
+    .internal-note__category,
+    .internal-note__warning {
+        padding: 0 $vr/4;
+        border-radius: 2px;
+        background-color: $color-grey-7;
+    }
+
+    .internal-note__warning {
+        background-color: $color-red-light;
+        color: $color-red-dark;
+    }
+
+    .internal-note--warning .internal-note__text {
+        font-weight: bold;
+    }
+
+    // the disclosure triangle would show up inside the button
+    summary.button {
+        list-style: none;
+
+        &::-webkit-details-marker {
+            display: none;
+        }
+    }
+}

--- a/muckrock/assets/scss/pattern/_pattern.scss
+++ b/muckrock/assets/scss/pattern/_pattern.scss
@@ -11,6 +11,7 @@
 @import 'foia';
 @import 'foia-log';
 @import 'forms';
+@import 'internal-notes';
 @import 'manager';
 @import 'message';
 @import 'newsletter';

--- a/muckrock/assets/scss/view/_profile.scss
+++ b/muckrock/assets/scss/view/_profile.scss
@@ -72,6 +72,28 @@
             margin-right: $vr;
         }
     }
+    // These buttons are a mix of spans, links and submit buttons wrapped in
+    // forms, so they will not line up on their own: the form is a block and
+    // breaks the row, and the inline-flex button group takes its baseline from
+    // its own children's margins.
+    .actions > div {
+        @include display(flex);
+        @include flex-wrap(wrap);
+        @include align-items(center);
+        gap: $vr/2;
+        // the buttons drop their margins, so leave room for the drop shadow
+        margin-bottom: $vr/4;
+        > form {
+            margin: 0;
+        }
+        // only the buttons in the row itself - the contact modal is a child of
+        // this element too, and its buttons keep their own spacing
+        > .button,
+        > form > .button,
+        > .button-group > .button {
+            margin: 0;
+        }
+    }
 }
 
 .api-token {

--- a/muckrock/templates/accounts/internal_notes.html
+++ b/muckrock/templates/accounts/internal_notes.html
@@ -1,0 +1,69 @@
+{% comment %}
+Private staff notes about a user.  Rendered by the {% internal_notes user %}
+tag, which shows nothing to non-staff users.  Never include this template
+directly - go through the tag so the permission check cannot be skipped.
+{% endcomment %}
+{% if show_notes %}
+  <section class="internal-notes">
+    <h3>
+      Internal Notes
+      <small>Staff only &mdash; not visible to {{ notes_user.username }}</small>
+    </h3>
+
+    {% if notes %}
+      <ul class="internal-notes__list nostyle">
+        {% for item in notes %}
+          <li class="internal-note {% if item.note.warning_level %}internal-note--warning{% endif %}" id="note-{{ item.note.pk }}">
+            <p class="internal-note__meta">
+              <span class="internal-note__by">{{ item.note.by.profile.full_name|default:item.note.by.username }}</span>
+              <time datetime="{{ item.note.created|date:'c' }}">{{ item.note.created|date:'m/d/Y g:i a' }}</time>
+              {% if item.note.category %}
+                <span class="internal-note__category">{{ item.note.category }}</span>
+              {% endif %}
+              {% if item.note.warning_level %}
+                <span class="internal-note__warning">{{ item.note.get_warning_level_display }}</span>
+              {% endif %}
+            </p>
+            <div class="internal-note__text">{{ item.note.text|linebreaks }}</div>
+            <details class="internal-note__edit">
+              <summary class="button">Edit</summary>
+              <form method="post" action="{% url 'acct-note-update' idx=item.note.pk %}">
+                {% csrf_token %}
+                <input type="hidden" name="next" value="{{ next }}">
+                {% include 'lib/pattern/form.html' with form=item.form %}
+                <button type="submit" name="update_note" value="true" class="primary button">
+                  Save Note
+                </button>
+              </form>
+              <form method="post" action="{% url 'acct-note-delete' idx=item.note.pk %}">
+                {% csrf_token %}
+                <input type="hidden" name="next" value="{{ next }}">
+                <button type="submit" name="delete_note" value="true" class="red button"
+                        onclick="return confirm('Delete this note? This cannot be undone.')">
+                  Delete Note
+                </button>
+              </form>
+            </details>
+          </li>
+        {% endfor %}
+      </ul>
+    {% else %}
+      <p class="internal-notes__empty">No notes about {{ notes_user.username }} yet.</p>
+    {% endif %}
+
+    <details class="internal-notes__add">
+      <summary class="button">
+        <span class="internal-notes__label-closed">Add a note</span>
+        <span class="internal-notes__label-open">Cancel</span>
+      </summary>
+      <form method="post" action="{% url 'acct-note-create' idx=notes_user.pk %}">
+        {% csrf_token %}
+        <input type="hidden" name="next" value="{{ next }}">
+        {% include 'lib/pattern/form.html' with form=note_form %}
+        <button type="submit" name="add_note" value="true" class="primary button">
+          Add Note
+        </button>
+      </form>
+    </details>
+  </section>
+{% endif %}

--- a/muckrock/templates/accounts/internal_notes.html
+++ b/muckrock/templates/accounts/internal_notes.html
@@ -1,3 +1,4 @@
+{% load tags %}
 {% comment %}
 Private staff notes about a user.  Rendered by the {% internal_notes user %}
 tag, which shows nothing to non-staff users.  Never include this template
@@ -24,7 +25,7 @@ directly - go through the tag so the permission check cannot be skipped.
                 <span class="internal-note__warning">{{ item.note.get_warning_level_display }}</span>
               {% endif %}
             </p>
-            <div class="internal-note__text">{{ item.note.text|linebreaks }}</div>
+            <div class="internal-note__text">{{ item.note.text|markdown }}</div>
             <details class="internal-note__edit">
               <summary class="button">Edit</summary>
               <form method="post" action="{% url 'acct-note-update' idx=item.note.pk %}">

--- a/muckrock/templates/accounts/profile.html
+++ b/muckrock/templates/accounts/profile.html
@@ -1,4 +1,5 @@
 {% extends 'base_profile.html' %}
+{% load account_tags %}
 {% load tags %}
 {% load static %}
 
@@ -133,6 +134,8 @@
       {% endif %}
     </div>
   </section>
+
+  {% internal_notes user_obj %}
 
   {% if request.user == user_obj %}
     <section class="buy">

--- a/muckrock/templates/foia/foiacomposer_detail.html
+++ b/muckrock/templates/foia/foiacomposer_detail.html
@@ -1,4 +1,5 @@
 {% extends 'base.html' %}
+{% load account_tags %}
 
 {% block title %}
   {{ composer.title }}
@@ -43,6 +44,8 @@
     <a href="{% url "foia-create" %}?clone={{ composer.pk }}" class="blue button">
       Clone
     </a>
+
+    {% internal_notes composer.user %}
 
     <section class="requests" id="requests">
       <h2>{{ foias|length }} Request{{ foias|length|pluralize }}</h2>

--- a/muckrock/templates/task/default.html
+++ b/muckrock/templates/task/default.html
@@ -24,7 +24,7 @@
     </header>
     <section class="collapsable {% if not task.note %}collapsed{% endif %} task__note">
       <header class="textbox__header">
-        <p class="{% if task.note %}has-note{% endif %}">Note</p>
+        <p class="{% if task.note %}has-note{% endif %}">{% block task-note-title %}Note{% endblock %}</p>
       </header>
       <main>
         <form method="POST" action="{{ endpoint }}?{{ request.META.QUERY_STRING }}" class="note-form">

--- a/muckrock/templates/task/multirequest.html
+++ b/muckrock/templates/task/multirequest.html
@@ -2,6 +2,9 @@
 {% load account_tags %}
 {% load tags %}
 
+{# these notes are about the request - internal notes are about the user #}
+{% block task-note-title %}Task Notes{% endblock %}
+
 {% block task-content %}
   <summary class="task__data multirequest">
     <p><a href="{% url 'admin:foia_foiacomposer_change' task.composer.id %}">{{task.composer.title|moderation_hl}}</a> was created by <a href="{% url 'admin:auth_user_change' task.composer.user.id %}">{{task.composer.user}}</a> and requires approval.</p>

--- a/muckrock/templates/task/multirequest.html
+++ b/muckrock/templates/task/multirequest.html
@@ -1,4 +1,5 @@
 {% extends 'task/default.html' %}
+{% load account_tags %}
 {% load tags %}
 
 {% block task-content %}
@@ -16,6 +17,7 @@
       {% endfor %}
     </ul>
   </summary>
+  {% internal_notes task.composer.user %}
 {% endblock %}
 
 {% block task-actions %}


### PR DESCRIPTION
This is on user profiles, multi-requests and multi-request tasks.

<img width="1425" height="793" alt="Screenshot 2026-07-29 at 12 56 55 PM" src="https://github.com/user-attachments/assets/5d075fc2-4576-421b-aa4a-ffb5260012c4" />

Closes #2237 