### PR TITLE
Better handle uploads to DocumentCloud

### DIFF
--- a/muckrock/foia/constants.py
+++ b/muckrock/foia/constants.py
@@ -166,3 +166,11 @@ EMAIL_STYLES = [
     "text-transform",
     "vertical-align",
 ]
+
+# file type magic bytes, keyed by extension, for verifying that a file's
+# contents match its claimed extension (see validate_file_type)
+FILE_MAGIC_BYTES = {
+    "pdf": [b"%PDF-"],
+    "docx": [b"PK\x03\x04"],  # OOXML zip container
+    "doc": [b"\xd0\xcf\x11\xe0\xa1\xb1\x1a\xe1"],  # legacy OLE2
+}

--- a/muckrock/foia/tasks.py
+++ b/muckrock/foia/tasks.py
@@ -137,13 +137,24 @@ def upload_document_cloud(ffile_pk):
 
     dc_client = get_dc_client()
 
-    _upload_documentcloud(
-        dc_client,
-        ffile,
-        change,
-        save_doc_attrs=True,
-        extra_params={"revision_control": True},
-    )
+    try:
+        _upload_documentcloud(
+            dc_client,
+            ffile,
+            change,
+            save_doc_attrs=True,
+            extra_params={"revision_control": True},
+        )
+    except (DocumentCloudError, requests.ReadTimeout) as exc:
+        if upload_document_cloud.request.retries >= 10:
+            logger.warning(
+                "DocumentCloud upload failed for FOIAFile %s (source: %s): %s",
+                ffile.pk,
+                ffile.source,
+                exc,
+                exc_info=sys.exc_info(),
+            )
+        raise
 
 
 @shared_task(

--- a/muckrock/foia/tasks.py
+++ b/muckrock/foia/tasks.py
@@ -99,7 +99,7 @@ def is_valid_file_type(ffile):
     ignore_result=True,
     time_limit=600,
     name="muckrock.foia.tasks.upload_document_cloud",
-    autoretry_for=(DocumentCloudError, requests.ReadTimeout),
+    autoretry_for=(DocumentCloudError, requests.exceptions.RequestException),
     retry_backoff=60,
     retry_kwargs={"max_retries": 10},
 )

--- a/muckrock/foia/tasks.py
+++ b/muckrock/foia/tasks.py
@@ -348,18 +348,11 @@ def composer_delayed_submit(composer_pk, approve, contact_info, **kwargs):
         composer.multirequesttask_set.create()
 
 
-def get_text_ocr(doc_id):
-    """Get the text OCR from document cloud"""
-
+def get_document(doc_id):
+    """Helper to fetch a document from DocumentCloud"""
     dc_client = get_dc_client()
-
-    try:
-        document = dc_client.documents.get(doc_id)
-    except DocumentCloudError as exc:
-        logger.warning("Doc Cloud error for %s: %s", doc_id, exc.error)
-        return ""
-
-    return document.full_text
+    document = dc_client.documents.get(doc_id)
+    return document
 
 
 def resolve_gloo_if_possible(resp_task, extracted_data):
@@ -414,7 +407,11 @@ def resolve_gloo_if_possible(resp_task, extracted_data):
 
 
 @shared_task(
-    ignore_result=True, max_retries=3, name="muckrock.foia.tasks.classify_status"
+    ignore_result=True,
+    max_retries=3,
+    name="muckrock.foia.tasks.classify_status",
+    autoretry_for=(DocumentCloudError, requests.ReadTimeout),
+    retry_backoff=60,
 )
 def classify_status(task_pk, **kwargs):
     """Use a machine learning classifier to predict the communications status"""
@@ -427,11 +424,29 @@ def classify_status(task_pk, **kwargs):
     file_text = []
     total_pages = 0
     for file_ in resp_task.communication.files.all():
+        # For each DC file with a doc ID, fetch the document and branch on status.
+        # If success -> use its text. If still processing -> retry later.
+        # Terminal (error/nofile) -> no text coming, classify without it.
+        # Any DocumentCloudError from the fetches propagates to autoretry_for.
         total_pages += file_.pages
+
         if file_.is_doccloud() and file_.doc_id:
-            file_text.append(get_text_ocr(file_.doc_id))
+            document = get_document(file_.doc_id)
+            if document.status in ("success", "readable"):
+                file_text.append(document.full_text)
+            elif document.status == "pending":
+                # still processing — wait longer for DocumentCloud
+                classify_status.retry(countdown=60 * 30, args=[task_pk], kwargs=kwargs)
+            elif document.status in ("error", "nofile"):
+                # terminal — processing failed or no file uploaded; no text is
+                # coming, so classify without this file, don't retry again
+                logger.warning(
+                    "Doc Cloud doc %s in terminal state %s, classifying without it",
+                    file_.doc_id,
+                    document.status,
+                )
         elif file_.is_doccloud() and not file_.doc_id:
-            # wait longer for document cloud
+            # not uploaded yet — wait longer for document cloud
             classify_status.retry(countdown=60 * 30, args=[task_pk], kwargs=kwargs)
 
     # new classify

--- a/muckrock/foia/tasks.py
+++ b/muckrock/foia/tasks.py
@@ -92,14 +92,6 @@ def is_valid_file_type(ffile):
         head = f.read(read_len)
 
     valid = any(head.startswith(sig) for sig in expected)
-    if not valid:
-        logger.warning(
-            "FOIAFile %s claims .%s but content starts with %r (source: %s)",
-            ffile.pk,
-            ext,
-            head,
-            ffile.source,
-        )
     return valid
 
 
@@ -455,9 +447,9 @@ def resolve_gloo_if_possible(resp_task, extracted_data):
 
 @shared_task(
     ignore_result=True,
-    max_retries=3,
+    max_retries=10,
     name="muckrock.foia.tasks.classify_status",
-    autoretry_for=(DocumentCloudError, requests.ReadTimeout),
+    autoretry_for=(DocumentCloudError, requests.exceptions.RequestException),
     retry_backoff=60,
 )
 def classify_status(task_pk, **kwargs):

--- a/muckrock/foia/tasks.py
+++ b/muckrock/foia/tasks.py
@@ -54,6 +54,7 @@ from muckrock.communication.models import (
 from muckrock.core.models import ExtractDay
 from muckrock.core.tasks import AsyncFileDownloadTask
 from muckrock.core.utils import get_dc_client, read_in_chunks, squarelet_get
+from muckrock.foia.constants import FILE_MAGIC_BYTES
 from muckrock.foia.exceptions import SizeError
 from muckrock.foia.models import (
     FOIACommunication,
@@ -71,6 +72,35 @@ foia_url = r"(?P<jurisdiction>[\w\d_-]+)-(?P<jidx>\d+)/(?P<slug>[\w\d_-]+)-(?P<i
 logger = logging.getLogger(__name__)
 
 lob.api_key = settings.LOB_SECRET_KEY
+
+
+class InvalidFileTypeError(Exception):
+    """A FOIAFile's contents don't match its claimed extension"""
+
+
+def is_valid_file_type(ffile):
+    """Return whether a FOIAFile's contents match its claimed extension.
+    This only runs on approved filetypes before uploading to DocumentCloud
+    and acts a filter to stop junk from being uploaded"""
+    ext = ffile.get_extension()
+    expected = FILE_MAGIC_BYTES.get(ext)
+    if expected is None:
+        return True
+
+    read_len = max(len(sig) for sig in expected)
+    with ffile.ffile.open("rb") as f:
+        head = f.read(read_len)
+
+    valid = any(head.startswith(sig) for sig in expected)
+    if not valid:
+        logger.warning(
+            "FOIAFile %s claims .%s but content starts with %r (source: %s)",
+            ffile.pk,
+            ext,
+            head,
+            ffile.source,
+        )
+    return valid
 
 
 @shared_task(
@@ -95,6 +125,12 @@ def upload_document_cloud(ffile_pk):
     if not ffile.is_doccloud():
         # not a file doc cloud supports, do not attempt to upload
         return
+
+    if not is_valid_file_type(ffile):
+        raise InvalidFileTypeError(
+            f"FOIAFile {ffile.pk} claims .{ffile.get_extension()} "
+            "but content does not match"
+        )
 
     # if it has a doc_id already, we are changing it, not creating it
     change = bool(ffile.doc_id)

--- a/muckrock/foia/tests/test_tasks.py
+++ b/muckrock/foia/tests/test_tasks.py
@@ -1,20 +1,31 @@
 # Django
+from celery.exceptions import Retry
 from django.conf import settings
 from django.db import connection, reset_queries
-from django.test import TestCase
+from django.test import TestCase, override_settings
+
+# Standard Library
+from unittest.mock import MagicMock, patch
 
 # Third Party
 import boto3
+from constance.test import override_config
 from moto import mock_aws
 
 # MuckRock
 from muckrock.core.factories import UserFactory
-from muckrock.foia.factories import FOIARequestFactory
-from muckrock.foia.tasks import ExportCsv
+from muckrock.foia.factories import FOIAFileFactory, FOIARequestFactory
+from muckrock.foia.tasks import (
+    ExportCsv,
+    InvalidFileTypeError,
+    classify_status,
+    is_valid_file_type,
+    upload_document_cloud,
+)
+from muckrock.task.factories import ResponseTaskFactory
 
 
 class ExportCsvTests(TestCase):
-
     @mock_aws
     def test_db_calls(self):
         user = UserFactory()
@@ -23,7 +34,6 @@ class ExportCsvTests(TestCase):
 
         def get_num_queries(batch_size):
             foias = FOIARequestFactory.create_batch(batch_size)
-
             try:
                 settings.DEBUG = True
                 reset_queries()
@@ -32,7 +42,152 @@ class ExportCsvTests(TestCase):
             finally:
                 settings.DEBUG = False
                 reset_queries()
-
             return num_queries
 
         assert get_num_queries(1) == get_num_queries(10)
+
+
+@mock_aws
+class IsValidFileTypeTests(TestCase):
+    """Testing for valid file type logic"""
+
+    def setUp(self):
+        boto3.client("s3").create_bucket(Bucket=settings.AWS_STORAGE_BUCKET_NAME)
+
+    def test_matching_pdf_is_valid(self):
+        ffile = FOIAFileFactory(
+            ffile__filename="doc.pdf", ffile__data=b"%PDF-1.7\nrest of file"
+        )
+        self.assertTrue(is_valid_file_type(ffile))
+
+    def test_mismatched_content_is_invalid(self):
+        # claims .pdf but the bytes are a PNG
+        ffile = FOIAFileFactory(
+            ffile__filename="doc.pdf", ffile__data=b"\x89PNG\r\n\x1a\n"
+        )
+        self.assertFalse(is_valid_file_type(ffile))
+
+
+@mock_aws
+@override_settings(DOCCLOUD_EXTENSIONS=[".pdf"])
+class UploadDocumentCloudTests(TestCase):
+    """upload_document_cloud rejects content/extension mismatches before it
+    ever uploads. DOCCLOUD_EXTENSIONS is pinned so .pdf is a doccloud type and
+    .mp3 is not"""
+
+    def setUp(self):
+        boto3.client("s3").create_bucket(Bucket=settings.AWS_STORAGE_BUCKET_NAME)
+
+    @patch("muckrock.foia.tasks._upload_documentcloud")
+    @patch("muckrock.foia.tasks.get_dc_client")
+    def test_invalid_type_raises_and_does_not_upload(self, _mock_client, mock_upload):
+        # .pdf extension, but PNG bytes -> mismatch
+        ffile = FOIAFileFactory(
+            ffile__filename="doc.pdf", ffile__data=b"\x89PNG\r\n\x1a\n"
+        )
+        with self.assertRaises(InvalidFileTypeError):
+            upload_document_cloud(ffile.pk)
+        mock_upload.assert_not_called()
+
+    @patch("muckrock.foia.tasks._upload_documentcloud")
+    @patch("muckrock.foia.tasks.get_dc_client")
+    def test_valid_type_proceeds_to_upload(self, _mock_client, mock_upload):
+        ffile = FOIAFileFactory(
+            ffile__filename="doc.pdf", ffile__data=b"%PDF-1.7\nrest"
+        )
+        upload_document_cloud(ffile.pk)
+        mock_upload.assert_called_once()
+
+    @patch("muckrock.foia.tasks._upload_documentcloud")
+    @patch("muckrock.foia.tasks.get_dc_client")
+    def test_non_doccloud_skips_validation(self, _mock_client, mock_upload):
+        # .mp3 is not in DOCCLOUD_EXTENSIONS -> is_doccloud() False -> no upload
+        ffile = FOIAFileFactory(
+            ffile__filename="notes.mp3", ffile__data=b"not audio at all"
+        )
+        upload_document_cloud(ffile.pk)
+        mock_upload.assert_not_called()
+
+
+def _doc(status, full_text="extracted body"):
+    """Stand-in for a DocumentCloud Document exposing only what the loop reads."""
+    doc = MagicMock()
+    doc.status = status
+    doc.full_text = full_text
+    return doc
+
+
+@override_settings(DOCCLOUD_EXTENSIONS=[".pdf"])
+@override_config(ENABLE_GLOO=False)
+class ClassifyStatusTests(TestCase):
+    """Test for the classify status logic. Every file is a .pdf so is_doccloud()
+    is true and the status branch under test actually fires."""
+
+    @patch("muckrock.foia.tasks.get_document")
+    def test_success_fetches_and_completes(self, mock_get_doc):
+        mock_get_doc.return_value = _doc("success")
+        task = ResponseTaskFactory()
+        FOIAFileFactory(
+            comm=task.communication, ffile__filename="doc.pdf", doc_id="123-slug"
+        )
+
+        classify_status(task.pk)
+
+        mock_get_doc.assert_called_once_with("123-slug")
+
+    @patch("muckrock.foia.tasks.get_document")
+    def test_readable_also_uses_text(self, mock_get_doc):
+        # "readable" is treated the same as success for text extraction
+        mock_get_doc.return_value = _doc("readable")
+        task = ResponseTaskFactory()
+        FOIAFileFactory(
+            comm=task.communication, ffile__filename="doc.pdf", doc_id="123-slug"
+        )
+
+        classify_status(task.pk)
+
+        mock_get_doc.assert_called_once_with("123-slug")
+
+    @patch("muckrock.foia.tasks.classify_status.retry", side_effect=Retry())
+    @patch("muckrock.foia.tasks.get_document")
+    def test_pending_triggers_retry(self, mock_get_doc, mock_retry):
+        mock_get_doc.return_value = _doc("pending")
+        task = ResponseTaskFactory()
+        FOIAFileFactory(
+            comm=task.communication, ffile__filename="doc.pdf", doc_id="123-slug"
+        )
+
+        with self.assertRaises(Retry):
+            classify_status(task.pk)
+        mock_retry.assert_called()
+
+    @patch("muckrock.foia.tasks.classify_status.retry", side_effect=Retry())
+    @patch("muckrock.foia.tasks.get_document")
+    def test_terminal_status_classifies_without_retry(self, mock_get_doc, mock_retry):
+        # error/nofile are terminal
+        # just continue classification without that file
+        for terminal in ("error", "nofile"):
+            with self.subTest(status=terminal):
+                mock_retry.reset_mock()
+                mock_get_doc.return_value = _doc(terminal)
+                task = ResponseTaskFactory()
+                FOIAFileFactory(
+                    comm=task.communication,
+                    ffile__filename="doc.pdf",
+                    doc_id="123-slug",
+                )
+
+                classify_status(task.pk)
+
+                mock_retry.assert_not_called()
+
+    @patch("muckrock.foia.tasks.classify_status.retry", side_effect=Retry())
+    @patch("muckrock.foia.tasks.get_document")
+    def test_doccloud_file_without_doc_id_retries(self, mock_get_doc, mock_retry):
+        task = ResponseTaskFactory()
+        FOIAFileFactory(comm=task.communication, ffile__filename="doc.pdf", doc_id="")
+
+        with self.assertRaises(Retry):
+            classify_status(task.pk)
+        mock_get_doc.assert_not_called()
+        mock_retry.assert_called()

--- a/pip/dev-requirements.in
+++ b/pip/dev-requirements.in
@@ -8,7 +8,7 @@ ipdb # interactive debugger
 isort # sort imports
 moto[s3] # Used for mocking S3
 pip-audit # Used for auditing packages
-pip-tools # Keeps the requirements up to date
+pip-tools>=7.6.1,<8 # Keeps the requirements up to date
 pylint-django # Pylint for Django integration
 pytest # Used for testing
 pytest-django # Used for testing

--- a/pip/dev-requirements.txt
+++ b/pip/dev-requirements.txt
@@ -147,7 +147,7 @@ pip-audit==2.7.3
     # via -r pip/dev-requirements.in
 pip-requirements-parser==32.0.1
     # via pip-audit
-pip-tools==7.5.3
+pip-tools==7.6.1
     # via -r pip/dev-requirements.in
 platformdirs==2.5.2
     # via

--- a/pip/requirements.in
+++ b/pip/requirements.in
@@ -8,6 +8,7 @@ bleach # Used to sanitize any HTML we're rendering
 boto3 # Used to access AWS
 celery # Used to run async tasks
 chardet # Detect character encodings for user uploaded text files
+cryptography==50.0.0 # Used by token handling libraries
 daily-active-users # Log daily active users
 django-activity-stream # Used for notifications
 django-anymail[mailgun] # Use for sending email on production
@@ -49,6 +50,7 @@ furl # Used to manipulate urls
 fuzzywuzzy # fuzzy string matching for FM agency import
 google-api-python-client # Google analytics
 gunicorn # Python WSGI app server
+httplib2==0.32.0 # Used by oauth2client
 img2pdf # convert images to PDFs
 ipython # better python shell
 jsonfield # Used for storing JSON data, required by django-geojson

--- a/pip/requirements.txt
+++ b/pip/requirements.txt
@@ -12,7 +12,7 @@
     # via -r pip/requirements.in
 aiohappyeyeballs==2.6.1
     # via aiohttp
-aiohttp==3.13.3
+aiohttp==3.14.3
     # via -r pip/requirements.in
 aiosignal==1.4.0
     # via aiohttp
@@ -64,7 +64,7 @@ certifi==2024.7.4
     #   requests
     #   scout-apm
     #   sentry-sdk
-cffi==1.17.1
+cffi==2.1.1
     # via cryptography
 chardet==3.0.3
     # via
@@ -84,8 +84,9 @@ click-plugins==1.1.1
     # via celery
 click-repl==0.2.0
     # via celery
-cryptography==46.0.0
+cryptography==50.0.0
     # via
+    #   -r pip/requirements.in
     #   google-auth
     #   pyjwt
 cssselect==0.9.2
@@ -102,7 +103,7 @@ defusedxml==0.7.1
     #   social-auth-core
 deprecated==1.2.14
     # via pikepdf
-django==5.2.12
+django==5.2.15
     # via
     #   -r pip/requirements.in
     #   daily-active-users
@@ -258,8 +259,9 @@ googleapis-common-protos==1.72.0
     # via google-api-core
 gunicorn==23.0.0
     # via -r pip/requirements.in
-httplib2==0.19.0
+httplib2==0.32.0
     # via
+    #   -r pip/requirements.in
     #   google-api-python-client
     #   oauth2client
 idna==3.10
@@ -345,7 +347,7 @@ pickleshare==0.7.5
     # via ipython
 pikepdf==9.5.1
     # via img2pdf
-pillow==12.1.1
+pillow==12.3.0
     # via
     #   -r pip/requirements.in
     #   easy-thumbnails
@@ -409,9 +411,9 @@ pyjwt[crypto]==2.12.0
     #   social-auth-core
 pymdown-extensions==10.21
     # via -r pip/requirements.in
-pyparsing==2.4.7
+pyparsing==3.3.2
     # via httplib2
-pypdf==6.8.0
+pypdf==6.15.0
     # via -r pip/requirements.in
 python-dateutil==2.9.0
     # via
@@ -421,12 +423,14 @@ python-dateutil==2.9.0
     #   phaxio
     #   python-documentcloud
     #   zenpy
-python-documentcloud==4.1.0
+python-documentcloud==4.8.1
     # via -r pip/requirements.in
 python-levenshtein==0.25.1
     # via -r pip/requirements.in
 python-redis-lock[django]==3.7.0
     # via -r pip/requirements.in
+python-squarelet==0.3.0
+    # via python-documentcloud
 python-stdnum==1.13
     # via django-localflavor
 python3-openid==3.2.0
@@ -441,7 +445,9 @@ pyyaml==6.0.1
 rapidfuzz==3.14.3
     # via levenshtein
 ratelimit==2.2.1
-    # via python-documentcloud
+    # via
+    #   python-documentcloud
+    #   python-squarelet
 redis==3.5.3
     # via
     #   -r pip/requirements.in
@@ -468,6 +474,7 @@ requests[security]==2.32.5
     #   premailer
     #   pyjwkest
     #   python-documentcloud
+    #   python-squarelet
     #   requests-oauthlib
     #   scrapelib
     #   smart-open
@@ -535,12 +542,15 @@ stripe==8.11.0
     # via -r pip/requirements.in
 tiktoken==0.12.0
     # via -r pip/requirements.in
+token-bucket==0.4.0
+    # via python-documentcloud
 traitlets==5.14.3
     # via
     #   ipython
     #   matplotlib-inline
 typing-extensions==4.12.2
     # via
+    #   aiohttp
     #   aiosignal
     #   beautifulsoup4
     #   pydantic
@@ -559,11 +569,13 @@ uritemplate==3.0.0
     # via
     #   drf-spectacular
     #   google-api-python-client
-urllib3==2.6.3
+urllib3==2.7.0
     # via
+    #   -r pip/requirements.in
     #   botocore
     #   phaxio
     #   python-documentcloud
+    #   python-squarelet
     #   requests
     #   scout-apm
     #   scrapelib

--- a/pip/requirements.txt
+++ b/pip/requirements.txt
@@ -571,7 +571,6 @@ uritemplate==3.0.0
     #   google-api-python-client
 urllib3==2.7.0
     # via
-    #   -r pip/requirements.in
     #   botocore
     #   phaxio
     #   python-documentcloud


### PR DESCRIPTION
- Updates python-documentcloud so that it will use the new bucket based rate limiting to upload documents slower, which is less error prone
- Updates a bunch of other dependencies while I'm in there
- Let's DocumentCloud errors in classify_status propagate up to the task where it will retry instead of raising and failing, check status of the document so we aren't trying to access document.full_text when it isn't ready
- Log when a FOIAFile is failed to be uploaded to DocumentCloud after 10 attempts 
- Peaks into a FOIAFile to see if the beginning of it's content actually matches the file extension type, ensuring that junk files don't get uploaded (as discussed today). 

Should close #2188 and #2189 