### PR TITLE
Fix AttributeError when trying to access status_code on connectivity issues

### DIFF
--- a/muckrock/accounts/mixins.py
+++ b/muckrock/accounts/mixins.py
@@ -108,7 +108,7 @@ class BuyRequestsMixin:
             organization.add_requests(num_requests)
         except requests.exceptions.RequestException as exc:
             logger.warning("Payment error: %s", exc, exc_info=sys.exc_info())
-            if exc.response.status_code // 100 == 4:
+            if exc.response is not None and exc.response.status_code // 100 == 4:
                 messages.error(
                     self.request,
                     "Payment Error: {}".format(


### PR DESCRIPTION
If we are having connectivity issues with Stripe when a payment is made for example, we try to access status_code before we know a response exists. It could be that it timed out, in which case an AttributeError like this one in Sentry gets thrown: 
https://muckrock.sentry.io/issues/7658966191/?project=996&query=is%3Aunresolved&referrer=issue-stream
This guards against this so that it can reach else branch and produce the message accurately. Both get logged anyway 