### PR TITLE
Fix agency autocomplete validation

### DIFF
--- a/muckrock/agency/views.py
+++ b/muckrock/agency/views.py
@@ -370,6 +370,7 @@ class AgencyComposerAutocomplete(AgencyAutocomplete):
         "jurisdiction__parent__abbrev",
     )
     create_field = "name"
+    validate_create = True
 
     def get_queryset(self):
         """Filter by jurisdiction"""

--- a/muckrock/foia/querysets.py
+++ b/muckrock/foia/querysets.py
@@ -483,12 +483,6 @@ class FOIATemplateQuerySet(models.QuerySet):
             template = self._render_single(None, user, requested_docs, **kwargs)
         else:
             template = self._render_generic(user, requested_docs, **kwargs)
-
-        if template is None:
-            raise ValueError(
-                "No FOIA template found. A generic template (jurisdiction=None)"
-                " must exist. If this is a fresh environment, set one."
-            )
         if kwargs.get("split") and template:
             parts = template.split(requested_docs, 1)
             if len(parts) != 2:
@@ -496,7 +490,7 @@ class FOIATemplateQuerySet(models.QuerySet):
                     "FOIA template is missing the requested_docs"
                     " marker required for split rendering"
                 )
-            return parts[0], parts[1]
+            return [parts[0], parts[1]]
 
         return template
 

--- a/muckrock/foia/querysets.py
+++ b/muckrock/foia/querysets.py
@@ -484,8 +484,19 @@ class FOIATemplateQuerySet(models.QuerySet):
         else:
             template = self._render_generic(user, requested_docs, **kwargs)
 
+        if template is None:
+            raise ValueError(
+                "No FOIA template found. A generic template (jurisdiction=None)"
+                " must exist. If this is a fresh environment, set one."
+            )
         if kwargs.get("split") and template:
-            return template.split(requested_docs, 1)
+            parts = template.split(requested_docs, 1)
+            if len(parts) != 2:
+                raise ValueError(
+                    "FOIA template is missing the requested_docs"
+                    " marker required for split rendering"
+                )
+            return parts[0], parts[1]
 
         return template
 

--- a/pip/requirements.in
+++ b/pip/requirements.in
@@ -12,7 +12,7 @@ cryptography==50.0.0 # Used by token handling libraries
 daily-active-users # Log daily active users
 django-activity-stream # Used for notifications
 django-anymail[mailgun] # Use for sending email on production
-django-autocomplete-light==3.9.0rc5 # Autocomplete drop down inputs
+django-autocomplete-light==3.12.1 # Autocomplete drop down inputs
 django-celery-email # Send emails asynchronously using Celery
 django-choices # Define choices for a field
 django-constance # Use for dynamic settings

--- a/pip/requirements.txt
+++ b/pip/requirements.txt
@@ -110,6 +110,7 @@ django==5.2.15
     #   django-activity-stream
     #   django-anymail
     #   django-appconf
+    #   django-autocomplete-light
     #   django-celery-email
     #   django-choices
     #   django-cors-headers
@@ -146,7 +147,7 @@ django-appconf==1.0.4
     # via
     #   django-celery-email
     #   django-opensearch
-django-autocomplete-light==3.9.0rc5
+django-autocomplete-light==3.12.1
     # via -r pip/requirements.in
 django-celery-email==3.0.0
     # via -r pip/requirements.in
@@ -509,7 +510,6 @@ six==1.17.0
     #   -r pip/requirements.in
     #   bleach
     #   click-repl
-    #   django-autocomplete-light
     #   furl
     #   google-api-python-client
     #   oauth2client


### PR DESCRIPTION
Should fix https://github.com/MuckRock/issues/issues/66

I removed the None check in commit one because as-is right now it doesn't crash the app, just throws in the logs which although noisy is probably a better experience than throwing a ValueError and blocking a new developer from even seeing the autocomplete. 

I couldn't add a default FOIATemplate in a migration as it requires a user. Adding a user seed too seemed like out of scope for this PR, especially since the user wouldn't also live on Accounts and presumably anyone who is actually touching this part of the codebase in the future should just have data loaded to work with to develop on instead of an empty database. This is an overall seeding issue as even when you have a FOIATemplate set, you need a law which cascades into a jurisdiction and agency. 
This data seeding issue belongs in https://github.com/MuckRock/dev_data/issues instead for general developers.

Internally we have our own snapshot data we can pull that only comprises of staff data for testing. 

I tried upgrading to DAL 4.0.3 but there were visible breaking changes from 3.X that we need more time to address. This version is a minor revision bump and is recent as of February 2025, which I think is good enough to address the immediate issue. 
https://pypi.org/project/django-autocomplete-light/#history

You should be able to use the sample string in the issue to confirm this is fixed on this PR. This PR validates it on the backend, but doesn't display anything to user- just clears their existing entry. 

