### PR TITLE
When rejecting a new agency task, always send an email to the user

### DIFF
--- a/muckrock/task/models.py
+++ b/muckrock/task/models.py
@@ -858,7 +858,7 @@ class NewAgencyTask(Task):
         return "New Agency Task"
 
     def display(self):
-        """Display something useful and identifing"""
+        """Display something useful and identifying"""
         return self.agency.name
 
     def get_absolute_url(self):
@@ -872,57 +872,68 @@ class NewAgencyTask(Task):
         """Reject agency, resend to replacement if one is specified"""
         if replacement_agency is not None:
             self._resolve_agency(replacement_agency)
-            subject = f"Agency Updated: {self.agency}"
             if msg_text:
-                TemplateEmail(
-                    subject=subject,
-                    user=self.user,
-                    text_template="task/email/agency_rejected.txt",
-                    html_template="task/email/agency_rejected.html",
-                    extra_context={
-                        "agency": self.agency,
-                        "text": msg_text,
-                        "url": settings.MUCKROCK_URL,
-                    },
-                ).send(fail_silently=False)
+                self._send_rejection_email(
+                    subject=f"Agency Updated: {self.agency}",
+                    extra_context={"agency": self.agency, "text": msg_text},
+                )
         else:
             self.agency.status = "rejected"
             self.agency.save()
-            foias = self.agency.foiarequest_set.select_related("composer").annotate(
-                count=Count("composer__foias")
+            foias = list(
+                self.agency.foiarequest_set.select_related("composer").annotate(
+                    count=Count("composer__foias")
+                )
             )
+            self._notify_rejection(foias, msg_text)
+            self._return_and_cleanup(foias)
+
+    def _send_rejection_email(self, subject, extra_context):
+        """Send the agency-rejection email. Callers own the subject and context.
+        This adds the shared url and dispatches through the standard templates."""
+        TemplateEmail(
+            subject=subject,
+            user=self.user,
+            text_template="task/email/agency_rejected.txt",
+            html_template="task/email/agency_rejected.html",
+            extra_context={"url": settings.MUCKROCK_URL, **extra_context},
+        ).send(fail_silently=False)
+
+    def _notify_rejection(self, foias, msg_text):
+        """Email the user that their agency was rejected with no viable replacement.
+        Always sends an email, using default copy when staff provided no custom text."""
+        if foias:
             if msg_text:
-                # only send an email if message text was provided
-                if foias:
-                    subject = 'We need your help with your request, "{}"'.format(
-                        foias[0].title
-                    )
-                    if len(foias) > 1:
-                        subject += ", and others"
-                else:
-                    subject = f"Agency Rejected: {self.agency}"
-                TemplateEmail(
-                    subject=subject,
-                    user=self.user,
-                    text_template="task/email/agency_rejected.txt",
-                    html_template="task/email/agency_rejected.html",
-                    extra_context={
-                        "agency": self.agency,
-                        "foias": foias,
-                        "text": msg_text,
-                        "url": settings.MUCKROCK_URL,
-                    },
-                ).send(fail_silently=False)
-            for foia in foias:
-                foia.composer.return_requests(1)
-                foia.delete()
-            for composer in self.agency.composers.all():
-                composer.agencies.remove(self.agency)
-                if composer.foias.count() == 0:
-                    if composer.revokable():
-                        composer.revoke()
-                    composer.status = "started"
-                    composer.save()
+                subject = 'We need your help with your request, "{}"'.format(
+                    foias[0].title
+                )
+            else:
+                subject = 'Update on your request, "{}"'.format(foias[0].title)
+            if len(foias) > 1:
+                subject += ", and others"
+        else:
+            subject = f"Agency Rejected: {self.agency}"
+        self._send_rejection_email(
+            subject=subject,
+            extra_context={
+                "agency": self.agency,
+                "foias": foias,
+                "text": msg_text,
+            },
+        )
+
+    def _return_and_cleanup(self, foias):
+        """Return one credit per deleted request and reset emptied composers."""
+        for foia in foias:
+            foia.composer.return_requests(1)
+            foia.delete()
+        for composer in self.agency.composers.all():
+            composer.agencies.remove(self.agency)
+            if composer.foias.count() == 0:
+                if composer.revokable():
+                    composer.revoke()
+                composer.status = "started"
+                composer.save()
 
     def _resolve_agency(self, replacement_agency=None):
         """Approves or rejects an agency and re-submits the pending requests"""

--- a/muckrock/task/models.py
+++ b/muckrock/task/models.py
@@ -910,7 +910,8 @@ class NewAgencyTask(Task):
             else:
                 subject = 'Update on your request, "{}"'.format(foias[0].title)
             if len(foias) > 1:
-                subject += ", and others"
+                count = len(foias) - 1
+                subject += ", and {} other{}".format(count, "" if count == 1 else "s")
         else:
             subject = f"Agency Rejected: {self.agency}"
         self._send_rejection_email(

--- a/muckrock/task/tests/test_models.py
+++ b/muckrock/task/tests/test_models.py
@@ -3,6 +3,7 @@ Tests for Tasks models
 """
 
 # Django
+from django.core import mail
 from django.test import TestCase
 from django.test.utils import override_settings
 from django.urls import reverse
@@ -399,6 +400,22 @@ class NewAgencyTaskTests(TestCase):
         assert self.agency.status == "rejected"
         assert not self.user.is_active
         assert not FOIARequest.objects.filter(pk=existing_foia.pk).exists()
+
+    def test_reject_no_replacement_no_text_notifies_user(self):
+        """The no-text path renders the default template and sends one email."""
+        with requests_mock.Mocker() as mocker:
+            mock_squarelet(mocker)
+            FOIARequestFactory(agency=self.agency)
+            self.task.reject()
+        assert len(mail.outbox) == 1
+
+    def test_reject_no_replacement_with_text_notifies_user(self):
+        """The custom-text path also renders and sends one email."""
+        with requests_mock.Mocker() as mocker:
+            mock_squarelet(mocker)
+            FOIARequestFactory(agency=self.agency)
+            self.task.reject(msg_text="Please clarify the agency name.")
+        assert len(mail.outbox) == 1
 
 
 class ResponseTaskTests(TestCase):

--- a/muckrock/templates/task/email/agency_rejected.html
+++ b/muckrock/templates/task/email/agency_rejected.html
@@ -1,11 +1,12 @@
 {% extends 'message/base.html' %}
-
 {% block body %}
-
   <p>Hi,</p>
-
-  <p>{{ text|linebreaks }}</p>
-
+  {% if text %}
+    <p>{{ text|linebreaks }}</p>
+  {% else %}
+    <p>We weren't able to send your request to {{ agency }}. When you file to an agency that isn't already in our system, our team reviews it to confirm we have valid contact information. In this case we couldn't verify a working contact, so your request couldn't be sent.</p>
+    <p>We've returned the request credit to your account, and your request has been saved so you don't lose your work. If you think this was a mistake, or you'd like help finding the right agency, contact us at <a href="mailto:info@muckrock.com">info@muckrock.com</a>.</p>
+  {% endif %}
   {% if foias %}
     {% if replaced %}
       <p>
@@ -18,7 +19,6 @@
         agency’s name:
       </p>
     {% endif %}
-
     <ul>
       {% for foia in foias %}
         <li>
@@ -29,9 +29,6 @@
       {% endfor %}
     </ul>
   {% endif %}
-
   <p>Sincerely,<br>
   The MuckRock Team</p>
-
 {% endblock body %}
-

--- a/muckrock/templates/task/email/agency_rejected.html
+++ b/muckrock/templates/task/email/agency_rejected.html
@@ -4,21 +4,10 @@
   {% if text %}
     <p>{{ text|linebreaks }}</p>
   {% else %}
-    <p>We weren't able to send your request to {{ agency }}. When you file to an agency that isn't already in our system, our team reviews it to confirm we have valid contact information. In this case we couldn't verify a working contact, so your request couldn't be sent.</p>
-    <p>We've returned the request credit to your account, and your request has been saved so you don't lose your work. If you think this was a mistake, or you'd like help finding the right agency, contact us at <a href="mailto:info@muckrock.com">info@muckrock.com</a>.</p>
+    <p>We weren't able to send your {{ foias|length|pluralize:"request,requests" }} to {{ agency }}. When you file to an agency that isn't already in our system, our team reviews it to confirm we have valid contact information. In this case we couldn't verify a working contact, so {{ foias|length|pluralize:"it couldn't,they couldn't" }} be sent.</p>
   {% endif %}
   {% if foias %}
-    {% if replaced %}
-      <p>
-        Your request has been directed to {{ agency.name }}. If you believe
-        your request should go elsewhere, please let us know.
-      </p>
-    {% else %}
-      <p>
-        There’s a copy of your request draft here if you want to clarify the
-        agency’s name:
-      </p>
-    {% endif %}
+    <p>We've returned the request {{ foias|length|pluralize:"credit,credits" }} to your account, and your {{ foias|length|pluralize:"request has,requests have" }} been saved so you don't lose your work. If you think this was a mistake, or you'd like help finding the right agency, contact us at <a href="mailto:info@muckrock.com">info@muckrock.com</a>.</p>
     <ul>
       {% for foia in foias %}
         <li>

--- a/muckrock/templates/task/email/agency_rejected.txt
+++ b/muckrock/templates/task/email/agency_rejected.txt
@@ -1,19 +1,17 @@
 {% extends 'message/base.txt' %}
-
 {% block body %}
-
 Hi,
+{% if text %}{{ text }}
+{% else %}
+We weren't able to send your request to {{ agency }}. When you file to an agency that isn't already in our system, our team reviews it to confirm we have valid contact information. In this case we couldn't verify a working contact, so your request couldn't be sent.
 
-{{ text }}
-
+We've returned the request credit to your account. Your request has been saved below so you don't lose your work. If you think this was a mistake, or you'd like help finding the right agency,  contact us at info@muckrock.com.
+{% endif %}
 {% if foias %}
 {% for foia in foias %}
     * {{ foia.composer.title }} - {{ url }}{% if foia.count == 1%}{% url "foia-draft" idx=foia.composer.pk %}{% else %}{% url "foia-composer-detail" slug=foia.composer.slug idx=foia.composer.pk %}{% endif %}
 {% endfor %}
 {% endif %}
-
 Sincerely,
 The MuckRock Team
-
 {% endblock body %}
-

--- a/muckrock/templates/task/email/agency_rejected.txt
+++ b/muckrock/templates/task/email/agency_rejected.txt
@@ -3,11 +3,10 @@
 Hi,
 {% if text %}{{ text }}
 {% else %}
-We weren't able to send your request to {{ agency }}. When you file to an agency that isn't already in our system, our team reviews it to confirm we have valid contact information. In this case we couldn't verify a working contact, so your request couldn't be sent.
-
-We've returned the request credit to your account. Your request has been saved below so you don't lose your work. If you think this was a mistake, or you'd like help finding the right agency,  contact us at info@muckrock.com.
+We weren't able to send your {{ foias|length|pluralize:"request,requests" }} to {{ agency }}. When you file to an agency that isn't already in our system, our team reviews it to confirm we have valid contact information. In this case we couldn't verify a working contact, so {{ foias|length|pluralize:"it couldn't,they couldn't" }} be sent.
 {% endif %}
 {% if foias %}
+We've returned the request {{ foias|length|pluralize:"credit,credits" }} to your account. Your {{ foias|length|pluralize:"request has,requests have" }} been saved below so you don't lose your work. If you think this was a mistake, or you'd like help finding the right agency, contact us at info@muckrock.com.
 {% for foia in foias %}
     * {{ foia.composer.title }} - {{ url }}{% if foia.count == 1%}{% url "foia-draft" idx=foia.composer.pk %}{% else %}{% url "foia-composer-detail" slug=foia.composer.slug idx=foia.composer.pk %}{% endif %}
 {% endfor %}


### PR DESCRIPTION
Even if staff didn't supply any custom text. 

Refactors reject() into some helpers as it was getting quite long with the branches. Adds some tests. Expands on the existing template. Sends the custom text if it is supplied, if it isn't, it sends the default message from the else. 

Closes #2241 