### PR TITLE
Fix the FBI portal, add tests and retries

### DIFF
--- a/muckrock/core/utils.py
+++ b/muckrock/core/utils.py
@@ -26,6 +26,8 @@ import boto3
 import requests
 import stripe
 from documentcloud import DocumentCloud
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
 from zenpy import Zenpy
 from zenpy.lib.api_objects import (
     Comment,
@@ -468,3 +470,36 @@ def get_dc_client():
         f"{existing_ua} {settings.SERVICE_USER_AGENT}".strip()
     )
     return client
+
+
+def requests_retry_session(
+    retries=3,
+    backoff_factor=0.3,
+    status_forcelist=(429, 500, 502, 503, 504),
+    allowed_methods=Retry.DEFAULT_ALLOWED_METHODS,
+    session=None,
+):
+    """Automatic retries for HTTP requests.
+    I've modified it to allow the method caller to specify
+    allowed_methods so that in the case where a POST is effectively just
+    a mask for GET request, it can be retried.
+    This is used in the FBI portal task.
+    This is because urllib3's Retry utility by default
+    does not allow for POST retries:
+    print(Retry.DEFAULT_ALLOWED_METHODS)
+    frozenset({'TRACE', 'HEAD', 'OPTIONS', 'GET', 'DELETE', 'PUT'})
+    See: https://www.peterbe.com/plog/best-practice-with-retries-with-requests
+    """
+    session = session or requests.Session()
+    retry = Retry(
+        total=retries,
+        read=retries,
+        connect=retries,
+        backoff_factor=backoff_factor,
+        status_forcelist=status_forcelist,
+        allowed_methods=allowed_methods,
+    )
+    adapter = HTTPAdapter(max_retries=retry)
+    session.mount("http://", adapter)
+    session.mount("https://", adapter)
+    return session

--- a/muckrock/portal/portals/fbi.py
+++ b/muckrock/portal/portals/fbi.py
@@ -7,20 +7,27 @@ Logic for interacting with FBI portals automatically
 from django.utils import timezone
 
 # Standard Library
+import logging
 import os
 import re
+import time
 
 # Third Party
 import requests
+import sentry_sdk
 
 # MuckRock
 from muckrock.communication.models import PortalCommunication
+from muckrock.core.utils import requests_retry_session
 from muckrock.foia.models import FOIACommunication
 from muckrock.portal.portals.automated import PortalAutoReceiveMixin
 from muckrock.portal.portals.manual import ManualPortal
 from muckrock.portal.tasks import portal_task
 
 FBI_PORTAL_EMAIL = os.environ.get("FBI_PORTAL_EMAIL", "")
+FBI_DOWNLOAD_DELAY = int(os.environ.get("FBI_DOWNLOAD_DELAY", "5"))
+
+logger = logging.getLogger(__name__)
 
 
 class FBIPortal(PortalAutoReceiveMixin, ManualPortal):
@@ -57,19 +64,110 @@ class FBIPortal(PortalAutoReceiveMixin, ManualPortal):
         else:
             ManualPortal.receive_msg(self, comm, reason="Unexpected email format")
 
+    def _raw_email_body(self, comm):
+        """Return the text/plain body from the raw email.
+
+        comm.communication is stripped to just the intro line, dropping the
+        download links and tokens, so we grab the raw email.
+        """
+        email_comm = comm.emails.first()
+        if email_comm is None or not hasattr(email_comm, "rawemail"):
+            return None
+        text, _html = email_comm.rawemail.get_text_html()
+        return text or None
+
     def document_reply_task(self, comm_pk):
-        """Download the documents asynchornously"""
+        """Download the documents asynchronously"""
         comm = FOIACommunication.objects.get(pk=comm_pk)
-        p_document_link = re.compile(r"\* \[(?P<name>[^\]]+)\]\((?P<url>.*)\)")
-        for name, url in p_document_link.findall(comm.communication):
-            reply = requests.get(url, timeout=10)
-            if reply.status_code != 200:
-                ManualPortal.receive_msg(
-                    self, comm, reason="Error downloading file: {}".format(name)
-                )
+        body = self._raw_email_body(comm)
+        if body is None:
+            self._report_broken(comm, "Could not read text/plain from raw email")
+            return
+
+        # Each file link is followed by a per-file token, and the download URL
+        # is a token-gated page. POST the token to the URL to get the bytes.
+        p_document = re.compile(
+            r"\* \[(?P<name>[^\]]+)\]\((?P<url>[^)]+)\)"
+            r"\s*\* Use this token to access:\s*(?P<token>\S+)"
+        )
+        # Every link should pair with a token; if not, the format changed again.
+        p_link_only = re.compile(r"\* \[[^\]]+\]\([^)]+\)")
+        matches = list(p_document.finditer(body))
+        if len(matches) != len(p_link_only.findall(body)):
+            self._report_broken(comm, "Could not pair every file link with a token")
+            return
+
+        # skip files already attached so a rerun doesn't duplicate them.
+        # attach_file stores the extension-stripped basename as `title`, so
+        # compare against the same transform to match already-attached files.
+        existing = set(comm.files.values_list("title", flat=True))
+
+        # retries 429/5xx with exponential backoff at the adapter layer.
+        # The tokens are valid for 48 hours, so retrying the POST is safe.
+        # POST must be added to allowed_methods because urllib3's default
+        # frozenset excludes it (POSTs are not retried by default).
+        session = requests_retry_session(
+            retries=5, backoff_factor=2, allowed_methods=frozenset({"POST"})
+        )
+
+        for i, match in enumerate(matches):
+            name = match.group("name")
+            title = os.path.splitext(name)[0][:255]
+            if title in existing:
+                continue
+            if i > 0:
+                # space out requests proactively to avoid FBI rate limiting
+                time.sleep(FBI_DOWNLOAD_DELAY)
+            if not self._download_file(comm, session, match):
                 return
-            comm.attach_file(content=reply.content, name=name, source=self.portal.name)
         self._accept_comm(comm, "There are eFOIA files available for you to download.")
+
+    def _download_file(self, comm, session, match):
+        """POST the token and attach the file. Returns True on success, or
+        reports the failure to manual review and returns False."""
+        name = match.group("name")
+        url = match.group("url")
+        token = match.group("token")
+        try:
+            reply = session.post(
+                url,
+                data={"token": token, "download": "Download File"},
+                timeout=10,
+            )
+        except requests.RequestException as exc:
+            # exhausted retries or a non-retryable network error
+            self._report_broken(
+                comm, "Download failed after retries: {} ({})".format(name, exc)
+            )
+            return False
+
+        if reply.status_code != 200:
+            self._report_broken(
+                comm,
+                "Error downloading file: {} (status {})".format(
+                    name, reply.status_code
+                ),
+            )
+            return False
+        # A wrong/expired token re-renders the HTML gate with a 200
+        # This is a guard against saving the page instead of the file.
+        content_type = reply.headers.get("Content-Type", "").lower()
+        if "text/html" in content_type:
+            self._report_broken(
+                comm, "Token gate returned instead of a file: {}".format(name)
+            )
+            return False
+        comm.attach_file(content=reply.content, name=name, source=self.portal.name)
+        return True
+
+    def _report_broken(self, comm, reason):
+        """Route to manual review and alert that the automation is broken"""
+        logger.error("FBI portal automation failed: %s (comm %d)", reason, comm.pk)
+        sentry_sdk.capture_message(
+            "FBI portal automation failed: {} (comm {})".format(reason, comm.pk),
+            level="error",
+        )
+        ManualPortal.receive_msg(self, comm, reason=reason)
 
     def send_msg(self, comm, **kwargs):
         """Send a message via email if it is not a new submission"""

--- a/muckrock/portal/portals/fbi.py
+++ b/muckrock/portal/portals/fbi.py
@@ -19,7 +19,7 @@ import sentry_sdk
 # MuckRock
 from muckrock.communication.models import PortalCommunication
 from muckrock.core.utils import requests_retry_session
-from muckrock.foia.models import FOIACommunication
+from muckrock.foia.models import FOIACommunication, RawEmail
 from muckrock.portal.portals.automated import PortalAutoReceiveMixin
 from muckrock.portal.portals.manual import ManualPortal
 from muckrock.portal.tasks import portal_task
@@ -71,9 +71,12 @@ class FBIPortal(PortalAutoReceiveMixin, ManualPortal):
         download links and tokens, so we grab the raw email.
         """
         email_comm = comm.emails.first()
-        if email_comm is None or not hasattr(email_comm, "rawemail"):
+        if email_comm is None:
             return None
-        text, _html = email_comm.rawemail.get_text_html()
+        try:
+            text, _html = email_comm.rawemail.get_text_html()
+        except RawEmail.DoesNotExist:
+            return None
         return text or None
 
     def document_reply_task(self, comm_pk):

--- a/muckrock/portal/tests.py
+++ b/muckrock/portal/tests.py
@@ -8,10 +8,11 @@ from django.test import TestCase
 
 # Standard Library
 from datetime import date
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 # Third Party
 import pytest
+import requests
 import requests_mock
 
 # MuckRock
@@ -130,6 +131,24 @@ class TestFBIPortal(TestCase):
             url="https://www.example.com", name="Test Portal", type="fbi"
         )
 
+    def _set_raw_email(self, comm, plain_body):
+        """Put the FBI raw email body on the comm's auto-created raw email.
+
+        document_reply_task parses the raw email; comm.communication is stripped
+        to the intro line in production. Setting raw_email_db (not the S3 file)
+        is enough -- the raw_email property falls back to it.
+        """
+        raw = (
+            "From: efoia@subscriptions.fbi.gov\r\n"
+            "To: test@requests.muckrock.com\r\n"
+            "Subject: eFOIA files available\r\n"
+            'Content-Type: text/plain; charset="utf-8"\r\n'
+            "\r\n" + plain_body
+        )
+        raw_email = comm.emails.first().rawemail
+        raw_email.raw_email_db = raw
+        raw_email.save()
+
     def test_confirm_open(self):
         """Test receiving a confirmation message"""
         comm = FOIACommunicationFactory(
@@ -143,19 +162,148 @@ class TestFBIPortal(TestCase):
     @patch("muckrock.foia.tasks.upload_document_cloud.apply_async")
     @patch("muckrock.foia.tasks.classify_status.apply_async")
     def test_document_reply(self, mock_requests, mock_upload, mock_classify):
-        """Test receiving a confirmation message"""
+        """Documents are downloaded by POSTing the per-file token to the gate"""
         # pylint: disable=unused-argument
-        mock_requests.get("https://www.example.com/file1.pdf", text="File 1 Content")
-        mock_requests.get("https://www.example.com/file2.pdf", text="File 2 Content")
+        mock_requests.post(
+            "https://www.example.com/file1.pdf",
+            content=b"%PDF-1.2 File 1 Content",
+            headers={"Content-Type": "application/pdf"},
+        )
+        mock_requests.post(
+            "https://www.example.com/file2.pdf",
+            content=b"%PDF-1.2 File 2 Content",
+            headers={"Content-Type": "application/pdf"},
+        )
         comm = FOIACommunicationFactory(
             subject="eFOIA files available",
-            communication="There are eFOIA files available for you to download\n"
-            "* [file1.pdf](https://www.example.com/file1.pdf)\n"
-            "* [file2.pdf](https://www.example.com/file2.pdf)\n",
+            communication="There are eFOIA files available for you to download.",
+        )
+        self._set_raw_email(
+            comm,
+            "There are eFOIA files available for you to download.\r\n\r\n"
+            "You can download the files at:\r\n\r\n"
+            "  * [file1.pdf](https://www.example.com/file1.pdf)\r\n"
+            "    * Use this token to access: TOKEN1\r\n"
+            "  * [file2.pdf](https://www.example.com/file2.pdf)\r\n"
+            "    * Use this token to access: TOKEN2\r\n",
         )
         self.portal.receive_msg(comm)
+
+        posted = {req.url: req.text for req in mock_requests.request_history}
+        assert "token=TOKEN1" in posted["https://www.example.com/file1.pdf"]
+        assert "token=TOKEN2" in posted["https://www.example.com/file2.pdf"]
+        assert "download=Download+File" in posted["https://www.example.com/file1.pdf"]
+
         assert comm.files.count() == 2
-        assert comm.files.all()[0].ffile.read() == b"File 1 Content"
-        assert comm.files.all()[1].ffile.read() == b"File 2 Content"
+        assert comm.files.all()[0].ffile.read() == b"%PDF-1.2 File 1 Content"
+        assert comm.files.all()[1].ffile.read() == b"%PDF-1.2 File 2 Content"
         assert comm.portals.count() == 1
+        assert comm.responsetask_set.count() == 1
+
+    @requests_mock.Mocker()
+    def test_document_reply_html_gate_falls_back_to_manual(self, mock_requests):
+        """A rejected/expired token re-renders the HTML gate at 200 -- must not
+        be saved as a file, and should fall back to manual review"""
+        mock_requests.post(
+            "https://www.example.com/file1.pdf",
+            content=b"<!doctype html><html>token gate</html>",
+            headers={"Content-Type": "text/html"},
+        )
+        comm = FOIACommunicationFactory(
+            subject="eFOIA files available",
+            communication="There are eFOIA files available for you to download.",
+        )
+        self._set_raw_email(
+            comm,
+            "There are eFOIA files available for you to download.\r\n\r\n"
+            "  * [file1.pdf](https://www.example.com/file1.pdf)\r\n"
+            "    * Use this token to access: BADTOKEN\r\n",
+        )
+        self.portal.receive_msg(comm)
+
+        assert comm.files.count() == 0
+        assert PortalTask.objects.filter(communication=comm).exists()
+
+    @requests_mock.Mocker()
+    def test_document_reply_unpaired_link_falls_back_to_manual(self, mock_requests):
+        """A link without a following token means the format drifted -- fall
+        back to manual rather than downloading a subset"""
+        comm = FOIACommunicationFactory(
+            subject="eFOIA files available",
+            communication="There are eFOIA files available for you to download.",
+        )
+        self._set_raw_email(
+            comm,
+            "There are eFOIA files available for you to download.\r\n\r\n"
+            "  * [file1.pdf](https://www.example.com/file1.pdf)\r\n"
+            "    * Use this token to access: TOKEN1\r\n"
+            "  * [file2.pdf](https://www.example.com/file2.pdf)\r\n",
+        )
+        self.portal.receive_msg(comm)
+
+        assert comm.files.count() == 0
+        assert not mock_requests.request_history  # never attempted a download
+        assert PortalTask.objects.filter(communication=comm).exists()
+
+    @requests_mock.Mocker()
+    def test_document_reply_connection_error_falls_back_to_manual(self, mock_requests):
+        """A network error that outlives the retries falls back to manual"""
+        mock_requests.post(
+            "https://www.example.com/file1.pdf",
+            exc=requests.exceptions.ConnectionError,
+        )
+        comm = FOIACommunicationFactory(
+            subject="eFOIA files available",
+            communication="There are eFOIA files available for you to download.",
+        )
+        self._set_raw_email(
+            comm,
+            "There are eFOIA files available for you to download.\r\n\r\n"
+            "  * [file1.pdf](https://www.example.com/file1.pdf)\r\n"
+            "    * Use this token to access: TOKEN1\r\n",
+        )
+        self.portal.receive_msg(comm)
+
+        assert comm.files.count() == 0
+        assert PortalTask.objects.filter(communication=comm).exists()
+
+    @patch("muckrock.foia.tasks.upload_document_cloud.apply_async")
+    @patch("muckrock.foia.tasks.classify_status.apply_async")
+    @patch("muckrock.portal.portals.fbi.requests_retry_session")
+    def test_document_reply_retries_configured_and_saves(
+        self, mock_session_factory, mock_classify, mock_upload
+    ):
+        """The download uses a session configured to retry POSTs, and the
+        returned file is saved. The urllib3 retry itself is library behavior
+        exercised by the real session in production; here we confirm the
+        session is built for POST retries and the response is attached."""
+        # pylint: disable=unused-argument
+        ok = Mock(status_code=200, content=b"%PDF-1.2 File 1 Content")
+        ok.headers = {"Content-Type": "application/pdf"}
+        mock_session = Mock()
+        mock_session.post.return_value = ok
+        mock_session_factory.return_value = mock_session
+
+        comm = FOIACommunicationFactory(
+            subject="eFOIA files available",
+            communication="There are eFOIA files available for you to download.",
+        )
+        self._set_raw_email(
+            comm,
+            "There are eFOIA files available for you to download.\r\n\r\n"
+            "  * [file1.pdf](https://www.example.com/file1.pdf)\r\n"
+            "    * Use this token to access: TOKEN1\r\n",
+        )
+        self.portal.receive_msg(comm)
+
+        # the retrying session was configured to retry POSTs
+        _, kwargs = mock_session_factory.call_args
+        assert kwargs.get("retries") == 5
+        assert kwargs.get("allowed_methods") == frozenset({"POST"})
+
+        # the token was POSTed and the returned file saved
+        _, post_kwargs = mock_session.post.call_args
+        assert post_kwargs["data"]["token"] == "TOKEN1"
+        assert comm.files.count() == 1
+        assert comm.files.all()[0].ffile.read() == b"%PDF-1.2 File 1 Content"
         assert comm.responsetask_set.count() == 1


### PR DESCRIPTION
Fix for #2255 

- Adds requests_retry_session which we use in..like everything now with a modification to allow us to retry the POST due to intermittent issues. The token is not one time use and is safe to re-use, it does only last for 48 hours. 
- Logs to Sentry if this changes again
- The communication is truncating the download link and the token required to get the files, so we fetch it from the raw email
- An email may contain more than one 1 link and token. I verified this by peaking at some FBI responsive emails in the shell.

You can verify the logic of this is sound by testing pieces in the shell, which I've prepared here:


**1. Finding a communication like this:** 

```
from muckrock.foia.models import FOIACommunication

comm = (
    FOIACommunication.objects
    .filter(communication__contains="There are eFOIA files available")
    .order_by("-datetime")
    .first()
)
print(comm.pk, comm.datetime)
```


**2. decoding the email body:** 

```
def raw_email_body(comm):
    email_comm = comm.emails.first()
    if email_comm is None or not hasattr(email_comm, "rawemail"):
        return None
    text, _html = email_comm.rawemail.get_text_html()
    return text or None

body = raw_email_body(comm)
print(repr(body[:500]) if body else "None")
```


**3. Pair links with tokens**

```
import re

p_document = re.compile(
    r"\* \[(?P<name>[^\]]+)\]\((?P<url>[^)]+)\)"
    r"\s*\* Use this token to access:\s*(?P<token>\S+)"
)
p_link_only = re.compile(r"\* \[[^\]]+\]\([^)]+\)")

matches = list(p_document.finditer(body))
print("pairs:", len(matches), "links:", len(p_link_only.findall(body)))
for m in matches:
    print(m.group("name")[:40], m.group("token"))
```


**4. Posting the token gets us the files**

```
import requests

for m in matches:
    reply = requests.post(
        m.group("url"),
        data={"token": m.group("token"), "download": "Download File"},
        timeout=10,
    )
    ct = reply.headers.get("Content-Type", "").lower()
    is_gate = "text/html" in ct
    print(
        m.group("name")[:40],
        reply.status_code,
        ct,
        reply.content[:8],
        "GATE" if is_gate else "OK",
    )
```
