### PR TITLE
FBI portal follow up

### DIFF
--- a/muckrock/mailgun/views.py
+++ b/muckrock/mailgun/views.py
@@ -105,8 +105,8 @@ def _get_mail_body(post, foia=None):
     ]
     if stripped_text in bad_text:
         return post.get("body-plain")
-    elif foia and foia.portal and foia.portal.type == "nextrequest":
-        # mailgun seems to improperly strip nextrequest messages
+    elif foia and foia.portal and foia.portal.type in ("nextrequest", "fbi"):
+        # mailgun seems to improperly strip nextrequest and FBI messages
         return post.get("body-plain")
     else:
         return "%s\n%s" % (

--- a/muckrock/portal/portals/fbi.py
+++ b/muckrock/portal/portals/fbi.py
@@ -26,6 +26,9 @@ from muckrock.portal.tasks import portal_task
 
 FBI_PORTAL_EMAIL = os.environ.get("FBI_PORTAL_EMAIL", "")
 FBI_DOWNLOAD_DELAY = int(os.environ.get("FBI_DOWNLOAD_DELAY", "5"))
+# transient-failure retry budget for reading the raw-email body from S3
+FBI_BODY_MAX_RETRIES = int(os.environ.get("FBI_BODY_MAX_RETRIES", "5"))
+FBI_BODY_RETRY_DELAY = int(os.environ.get("FBI_BODY_RETRY_DELAY", "30"))
 
 logger = logging.getLogger(__name__)
 
@@ -65,11 +68,18 @@ class FBIPortal(PortalAutoReceiveMixin, ManualPortal):
             ManualPortal.receive_msg(self, comm, reason="Unexpected email format")
 
     def _raw_email_body(self, comm):
-        """Return the text/plain body from the raw email.
+        """Return the body containing the download links and per-file tokens.
 
-        comm.communication is stripped to just the intro line, dropping the
-        download links and tokens, so we grab the raw email.
+        The full body is present in the raw email's text/plain part.
+        Inbound ingest (muckrock/mailgun/views.py) stores Mailgun's
+        stripped-text into comm.communication, which unreliably strips the
+        FBI's link/token bullets. Communication is sometimes the full
+        body and sometimes just the intro line. Prefer communication when it
+        actually contains the tokens. Only then fall back to the raw email
+        (an S3 read that can be transiently empty right after delivery).
         """
+        if "Use this token to access" in (comm.communication or ""):
+            return comm.communication
         email_comm = comm.emails.first()
         if email_comm is None:
             return None
@@ -79,11 +89,25 @@ class FBIPortal(PortalAutoReceiveMixin, ManualPortal):
             return None
         return text or None
 
-    def document_reply_task(self, comm_pk):
+    def document_reply_task(self, comm_pk, attempt=0):
         """Download the documents asynchronously"""
         comm = FOIACommunication.objects.get(pk=comm_pk)
         body = self._raw_email_body(comm)
         if body is None:
+            # The body may only live in the raw email's text/plain part, which
+            # is stored in S3. Right after delivery that object may not be
+            # readable yet, and RawEmail.raw_email is an mproperty, so
+            # an empty read gets memoized for the life of the worker instance.
+            if attempt < FBI_BODY_MAX_RETRIES:
+                portal_task.apply_async(
+                    args=[
+                        self.portal.pk,
+                        "document_reply_task",
+                        [comm_pk, attempt + 1],
+                    ],
+                    countdown=FBI_BODY_RETRY_DELAY,
+                )
+                return
             self._report_broken(comm, "Could not read text/plain from raw email")
             return
 

--- a/muckrock/portal/portals/fbi.py
+++ b/muckrock/portal/portals/fbi.py
@@ -78,7 +78,7 @@ class FBIPortal(PortalAutoReceiveMixin, ManualPortal):
         actually contains the tokens. Only then fall back to the raw email
         (an S3 read that can be transiently empty right after delivery).
         """
-        if "Use this token to access" in (comm.communication or ""):
+        if comm.communication and "Use this token to access" in comm.communication:
             return comm.communication
         email_comm = comm.emails.first()
         if email_comm is None:


### PR DESCRIPTION
This PR solves two problems with yesterday's fix:

In all my testing, the communications were already truncated and the raw email bodies were available. Today, I see this sentry error:
https://muckrock.sentry.io/issues/7694439067/events/fb9ddcc5f13a4b85a598c3f6cde0f2fb/?notification_uuid=7758b047-bfc1-4a0f-bbbe-54b9cc99348b&project=996&referrer=regression_activity-email

When looking in the shell, the email body IS available, so it is a timing issue. It must not have been readable yet, which requires a retry. Looking at the request, however, I discover that the communication is now full and not truncated like the others were:
https://www.muckrock.com/foi/united-states-of-america-10/bill-walter-fbi-150170/

I traced this back to overzealous stripping done by Mailgun on the communication, which is also experienced by nextrequest, so I added the FBI portal to that list. The full truncated communication should be available to the task now and we can fall back to the raw email body only if this is missing. This also adds retry for the email body access as it can be subject to timing issues. 