### PR TITLE
Fix parse header so dropbox links work again

### DIFF
--- a/muckrock/core/utils.py
+++ b/muckrock/core/utils.py
@@ -18,6 +18,7 @@ import sys
 import time
 import uuid
 from email.message import Message
+from email.utils import collapse_rfc2231_value
 from hashlib import md5
 
 # Third Party
@@ -397,11 +398,21 @@ def custom_preprocessing_hook(endpoints):
 
 
 def parse_header(header):
-    """Replacement for deprecated cgi parse_header"""
+    """Replacement for the deprecated cgi.parse_header.
+
+    Parses a header value like a Content-Type or Content-Disposition into
+    its main value plus a dict of parameters like the following:
+    'attachment; filename="a.zip"' -> ('attachment', {'filename': 'a.zip'})
+
+    RFC 2231 extended parameters (e.g. filename*=UTF-8''a.zip, used by
+    Dropbox and some FOIA portals) are decoded to plain strings rather than
+    the (charset, language, value) tuples that Message.get_params returns.
+    """
     msg = Message()
     msg["content-type"] = header
-    params = msg.get_params()
-    return (params[0][0], dict(params[1:]))
+    main_value, *param_pairs = msg.get_params()
+    params = {key: collapse_rfc2231_value(value) for key, value in param_pairs}
+    return (main_value[0], params)
 
 
 def mailchimp_journey(email, journey):


### PR DESCRIPTION
**Sentry error:**
https://muckrock.sentry.io/issues/6988292417/?project=996&query=is%3Aunresolved&referrer=issue-stream

**Slack thread:**
https://muckrock.slack.com/archives/C023A6R5A4A/p1786626351790249

**How to replicate and verify fix in shell:**

1. Find the communication (2364416) in the shell from [this request](https://www.muckrock.com/foi/stillwater-1832/flock-safety-audit-mn-agencies-stillwater-police-department-214447/) (public)

Not pasting the dropbox link here as it will get scraped, but you'll see it. 

link = "paste the dropbox link here"

2. Confirm the bug 
```
import requests
from muckrock.core.utils import parse_header  # current buggy version

resp = requests.get(link, timeout=10)
resp.raise_for_status()
print(repr(resp.headers.get("content-disposition")))
_, params = parse_header(resp.headers.get("content-disposition", ""))
print(repr(params.get("filename")))   # -> ('UTF-8', '', 'Public.zip')  

```

3. Define the fixed parse_header and patch it in the shell to test and prove it works


```
from email.message import Message
from email.utils import collapse_rfc2231_value

def fixed_parse_header(header):
    msg = Message()
    msg["content-type"] = header
    main_value, *param_pairs = msg.get_params()
    params = {key: collapse_rfc2231_value(value) for key, value in param_pairs}
    return (main_value[0], params)

_, params = fixed_parse_header(resp.headers.get("content-disposition", ""))
print("FIXED filename:", repr(params.get("filename")), "| is str:", isinstance(params.get("filename"), str))


# confirm existing behavior is backwards-compatible
print(fixed_parse_header('application/json; charset="utf8"'))
```


4. Call download links with the patched header


```
import muckrock.mailgun.utils as mu
mu.parse_header = fixed_parse_header

mu.download_links(comm)
comm.refresh_from_db()
print("files after:", comm.files.count())
for f in comm.files.all():
    print(f.pk, f.title, f.ffile.name)
```