### PR TITLE
Try to handle HTML in email comms marked text/plain

### DIFF
--- a/muckrock/mailgun/tests.py
+++ b/muckrock/mailgun/tests.py
@@ -30,7 +30,14 @@ from muckrock.communication.models import EmailAddress, EmailError, EmailOpen
 from muckrock.core.test_utils import RunCommitHooksMixin
 from muckrock.foia.factories import FOIACommunicationFactory, FOIARequestFactory
 from muckrock.foia.models import FOIACommunication
-from muckrock.mailgun.views import bounces, delivered, opened, route_mailgun
+from muckrock.mailgun.views import (
+    _html_to_text,
+    _looks_like_html,
+    bounces,
+    delivered,
+    opened,
+    route_mailgun,
+)
 from muckrock.task.models import OrphanTask
 
 
@@ -510,3 +517,66 @@ class TestMailgunViewWebHooks(TestMailgunViews):
         assert comm.emails.first().confirmed_datetime == datetime(
             2017, 1, 2, 17, tzinfo=pytz.utc
         )
+
+
+class TestMailgunHtmlBody(TestCase):
+    """Tests for detecting and converting HTML sent in a text/plain part
+    (as Granicus/GovQA does)"""
+
+    # This is a trimmed down and anonymized real govqa comm body.
+    # HTML in what should be plain text
+    # with a link and a tracking image
+    GOVQA_BODY = (
+        '<br><br><div style="text-align: center;">'
+        '<img alt="" src="https://track.example/logo.png" width="100%" /></div>\r\n'
+        "<div>\r\n"
+        "<div>Dear s,</div>\r\n"
+        "<div>&nbsp;</div>\r\n"
+        "<div>Thank you for registering with the Records Center.</div>\r\n"
+        "<div>&nbsp;</div>\r\n"
+        '<div>Reset here: <a title="Reset" '
+        'href="https://portal.example/reset?tok=abc" target="_blank">'
+        "Request Temporary Password</a></div>\r\n"
+        "</div>"
+    )
+
+    def test_looks_like_html_detects_leading_tag(self):
+        """Bodies that open with an HTML tag are detected"""
+        assert _looks_like_html(self.GOVQA_BODY)
+        assert _looks_like_html("<div>hello</div>")
+        # Case with a leading whitespace
+        assert _looks_like_html("  \r\n<br><br><div>x</div>")
+
+    def test_html_to_text_strips_tags_and_keeps_content(self):
+        """Conversion removes markup but preserves the readable text"""
+        result = _html_to_text(self.GOVQA_BODY)
+        assert "<div" not in result
+        assert "<img" not in result
+        assert "&nbsp;" not in result
+        assert "Dear s," in result
+        assert "Thank you for registering with the Records Center." in result
+
+    def test_html_to_text_preserves_links(self):
+        """Anchor hrefs are inlined as text so the URL isn't lost"""
+        result = _html_to_text(self.GOVQA_BODY)
+        assert "Request Temporary Password" in result
+        assert "https://portal.example/reset?tok=abc" in result
+
+    def test_html_to_text_trims_malformed_href(self):
+        """A missing closing quote must not drag ` target=` into the href"""
+        body = (
+            '<div><a href="https://portal.example/x=1 target="_blank">'
+            "click</a></div>"
+        )
+        result = _html_to_text(body)
+        assert "https://portal.example/x=1" in result
+        assert "target=" not in result
+
+    def test_html_to_text_returns_body_on_conversion_failure(self):
+        """If parsing/conversion raises, the original body is returned unchanged
+        rather than propagating the error into email ingest"""
+        body = "<div>some content</div>"
+        with patch(
+            "muckrock.mailgun.views.BeautifulSoup", side_effect=Exception("boom")
+        ):
+            assert _html_to_text(body) == body

--- a/muckrock/mailgun/views.py
+++ b/muckrock/mailgun/views.py
@@ -16,6 +16,7 @@ from django.views.decorators.csrf import csrf_exempt
 # Standard Library
 import hashlib
 import hmac
+import html
 import json
 import logging
 import re
@@ -26,6 +27,7 @@ from email.utils import getaddresses
 from functools import wraps
 
 # Third Party
+from bs4 import BeautifulSoup
 from constance import config
 
 # MuckRock
@@ -104,15 +106,70 @@ def _get_mail_body(post, foia=None):
         "--- Please respond above this line ---\n",
     ]
     if stripped_text in bad_text:
-        return post.get("body-plain")
+        body = post.get("body-plain") or ""
     elif foia and foia.portal and foia.portal.type in ("nextrequest", "fbi"):
         # mailgun seems to improperly strip nextrequest and FBI messages
-        return post.get("body-plain")
+        body = post.get("body-plain") or ""
     else:
-        return "%s\n%s" % (
+        body = "%s\n%s" % (
             post.get("stripped-text", ""),
             post.get("stripped-signature", ""),
         )
+
+    # GovQA sends HTML with mimetype text/plain
+    # so the body we get is markup rather than text. We need
+    # to detect this reliably, strip it to readable text
+    # so it doesn't render as tag soup with linebreaks
+    if _looks_like_html(body):
+        body = _html_to_text(body)
+
+    return body
+
+
+def _looks_like_html(text):
+    """Body advertised as plain text but actually containing HTML markup.
+
+    Granicus/GovQA sends multipart/alternative mail whose text/plain part
+    is HTML. We need to be able to detect this with a heuristic and fix it.
+    """
+    if not text:
+        return False
+    head = text.lstrip()[:64].lower()
+    return head.startswith(
+        (
+            "<br",
+            "<div",
+            "<html",
+            "<table",
+            "<p ",
+            "<p>",
+            "<strong",
+            "<span",
+            "<img",
+            "<center",
+            "<!doctype",
+        )
+    )
+
+
+def _html_to_text(body):
+    """Convert an HTML email body to readable plain text, preserving links."""
+    soup = BeautifulSoup(body, "lxml")
+    for a in soup.find_all("a", href=True):
+        href = a["href"].strip()
+        # GovQA emits malformed attrs (missing closing quote), so the parsed
+        # href can trail into ` target=`, `>`, or a stray quote. A valid URL
+        # contains none of these unescaped so we cut at the first one.
+        href = re.split(r'[\s>"\']', href, 1)[0] if href else href
+        txt = a.get_text().strip()
+        if href and href not in txt:
+            a.replace_with(f"{txt} ({href})" if txt else href)
+    text = soup.get_text("\n")
+    text = html.unescape(text)
+    text = text.replace("\xa0", " ")
+    text = re.sub(r"[ \t]+", " ", text)
+    text = re.sub(r"\n\s*\n\s*\n+", "\n\n", text)
+    return text.strip()
 
 
 def mailgun_verify(function):

--- a/muckrock/mailgun/views.py
+++ b/muckrock/mailgun/views.py
@@ -119,8 +119,15 @@ def _get_mail_body(post, foia=None):
     # GovQA sends HTML with mimetype text/plain
     # so the body we get is markup rather than text. We need
     # to detect this reliably, strip it to readable text
-    # so it doesn't render as tag soup with linebreaks
+    # so it doesn't render as tag soup with linebreaks.
     if _looks_like_html(body):
+        # I've added logging here to log when this happens
+        # In case it comes from different sender in the future too.
+        logger.info(
+            "[MAILGUN] Converting HTML body sent as text/plain from %s (foia %s)",
+            post.get("From", "unknown"),
+            foia.pk if foia else None,
+        )
         body = _html_to_text(body)
 
     return body
@@ -141,8 +148,7 @@ def _looks_like_html(text):
             "<div",
             "<html",
             "<table",
-            "<p ",
-            "<p>",
+            "<p",
             "<strong",
             "<span",
             "<img",
@@ -154,22 +160,29 @@ def _looks_like_html(text):
 
 def _html_to_text(body):
     """Convert an HTML email body to readable plain text, preserving links."""
-    soup = BeautifulSoup(body, "lxml")
-    for a in soup.find_all("a", href=True):
-        href = a["href"].strip()
-        # GovQA emits malformed attrs (missing closing quote), so the parsed
-        # href can trail into ` target=`, `>`, or a stray quote. A valid URL
-        # contains none of these unescaped so we cut at the first one.
-        href = re.split(r'[\s>"\']', href, 1)[0] if href else href
-        txt = a.get_text().strip()
-        if href and href not in txt:
-            a.replace_with(f"{txt} ({href})" if txt else href)
-    text = soup.get_text("\n")
-    text = html.unescape(text)
-    text = text.replace("\xa0", " ")
-    text = re.sub(r"[ \t]+", " ", text)
-    text = re.sub(r"\n\s*\n\s*\n+", "\n\n", text)
-    return text.strip()
+    try:
+        soup = BeautifulSoup(body, "lxml")
+        for a in soup.find_all("a", href=True):
+            # GovQA emits malformed attrs (missing closing quote), so the parsed
+            # href can trail into ` target=`, `>`, or a stray quote. A valid URL
+            # contains none of these unescaped so we cut at the first one.
+            href = re.split(r'[\s>"\']', a["href"].strip(), 1)[0]
+            txt = a.get_text().strip()
+            # no usable URL "" returned, leave anchor text as-is
+            if not href:
+                continue
+            # Only show the URL if it's not already in the text
+            if href not in txt:
+                a.replace_with(f"{txt} ({href})" if txt else href)
+        text = soup.get_text("\n")
+        text = html.unescape(text)
+        text = text.replace("\xa0", " ")
+        text = re.sub(r"[ \t]+", " ", text)
+        text = re.sub(r"\n\s*\n\s*\n+", "\n\n", text)
+        return text.strip()
+    except Exception:  # pylint: disable=broad-except
+        logger.warning("Failed to convert HTML email body", exc_info=sys.exc_info())
+        return body
 
 
 def mailgun_verify(function):


### PR DESCRIPTION
Close #2270 

If an agency/portal sends us an email that contains HTML but the body is supposed to be text/plain, we inspect it to determine if it contains HTML and then format it using BeautifulSoup, which is a library we already use. 

I've run this on the shell on some communications from requests that do contain the HTML. Can DM screenshots as they contain portal log in links and such. 

