### PR TITLE
If the user who created a NewAgencyTask doesn't have an email, don't try to send one.

### DIFF
--- a/muckrock/task/models.py
+++ b/muckrock/task/models.py
@@ -891,6 +891,12 @@ class NewAgencyTask(Task):
     def _send_rejection_email(self, subject, extra_context):
         """Send the agency-rejection email. Callers own the subject and context.
         This adds the shared url and dispatches through the standard templates."""
+        if not (self.user and self.user.email):
+            logger.warning(
+                "Skipping agency rejection email for task %s: no recipient email",
+                self.pk,
+            )
+            return
         TemplateEmail(
             subject=subject,
             user=self.user,


### PR DESCRIPTION
Sentry error:
https://muckrock.sentry.io/issues/7384173661/events/4b93b4c5ee2d4a03868b383c9a05608d/?project=996&query=is%3Aunresolved&referrer=previous-event

If the user doesn't exist or doesn't have an email, don't send one when their new agency request gets denied.