### PR TITLE
Adds AuthenticatedAPIMixin that APIv2 uses into stats API

### DIFF
--- a/muckrock/accounts/stats_api/views.py
+++ b/muckrock/accounts/stats_api/views.py
@@ -19,6 +19,7 @@ from rest_framework.response import Response
 # MuckRock
 from muckrock.accounts.stats_api.models import UserStats
 from muckrock.accounts.stats_api.serializers import UserStatsSerializer
+from muckrock.core.views import AuthenticatedAPIMixin
 from muckrock.core.pagination import CursorPagination
 from muckrock.organization.models import Organization
 
@@ -65,7 +66,7 @@ class UserStatsFilter(django_filters.FilterSet):
         )
 
 
-class UserStatsViewSet(viewsets.ReadOnlyModelViewSet):
+class UserStatsViewSet(AuthenticatedAPIMixin, viewsets.ReadOnlyModelViewSet):
     """Staff-facing user activity stats."""
 
     serializer_class = UserStatsSerializer

--- a/muckrock/accounts/stats_api/views.py
+++ b/muckrock/accounts/stats_api/views.py
@@ -19,8 +19,8 @@ from rest_framework.response import Response
 # MuckRock
 from muckrock.accounts.stats_api.models import UserStats
 from muckrock.accounts.stats_api.serializers import UserStatsSerializer
-from muckrock.core.views import AuthenticatedAPIMixin
 from muckrock.core.pagination import CursorPagination
+from muckrock.core.views import AuthenticatedAPIMixin
 from muckrock.organization.models import Organization
 
 

--- a/muckrock/organization/stats_api/views.py
+++ b/muckrock/organization/stats_api/views.py
@@ -16,8 +16,10 @@ from rest_framework.decorators import action
 from rest_framework.permissions import IsAdminUser
 from rest_framework.response import Response
 
+
 # MuckRock
 from muckrock.core.pagination import CursorPagination
+from muckrock.core.views import AuthenticatedAPIMixin
 from muckrock.organization.stats_api.models import OrganizationStats
 from muckrock.organization.stats_api.serializers import OrganizationStatsSerializer
 
@@ -51,7 +53,7 @@ class OrganizationStatsFilter(django_filters.FilterSet):
     filter_active_within_days = filter_filed_within_days
 
 
-class OrganizationStatsViewSet(viewsets.ReadOnlyModelViewSet):
+class OrganizationStatsViewSet(AuthenticatedAPIMixin, viewsets.ReadOnlyModelViewSet):
     """Staff-facing organization activity stats."""
 
     serializer_class = OrganizationStatsSerializer

--- a/muckrock/organization/stats_api/views.py
+++ b/muckrock/organization/stats_api/views.py
@@ -16,7 +16,6 @@ from rest_framework.decorators import action
 from rest_framework.permissions import IsAdminUser
 from rest_framework.response import Response
 
-
 # MuckRock
 from muckrock.core.pagination import CursorPagination
 from muckrock.core.views import AuthenticatedAPIMixin


### PR DESCRIPTION
MuckRock's default authentication classes are token authentication (old, v1) and SessionAuthentication. We need JWT token authentication, which I ran into already with APIv2 and had a mixin ready. This just adds that mixin. 